### PR TITLE
Use binaries for xml attribute names in the IQ macro

### DIFF
--- a/include/exmpp_xmpp.hrl
+++ b/include/exmpp_xmpp.hrl
@@ -69,7 +69,7 @@
 -define(IQ(Type, To, Id), (
   exmpp_xml:set_attributes(
     #xmlel{ns = ?NS_JABBER_CLIENT, name = 'iq'},
-      [{'type', Type}, {'to', To}, {'id', Id}])
+      [{<<"type">>, Type}, {<<"to">>, To}, {<<"id">>, Id}])
 )).
 
 -define(IQ_GET(To, Id), (


### PR DESCRIPTION
The IQ macro is only used by the IQ_GET and IQ_SET macros, which
are only used by the exmpp_client_pubsub and exmpp_client_disco modules.

https://support.process-one.net/browse/EXMPP-40
