### PR TITLE
OSX Lion Incompatibility

### DIFF
--- a/c_src/exmpp_tls_openssl.c
+++ b/c_src/exmpp_tls_openssl.c
@@ -21,6 +21,10 @@
 
 #include "exmpp_tls.h"
 
+#if (defined(__MACH__) && defined(__APPLE__))
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #define	DRIVER_NAME	exmpp_tls_openssl
 #define CIPHERS         "DEFAULT:!EXPORT:!LOW:!SSLv2"
 


### PR DESCRIPTION
While trying to build on Lion, I noticed some OpenSSH deprecation warnings that prevented me from compiling. It looks like Apple has deprecated it, in favor of their own TLS implementation (cc_crypto). 

It doesn't look very compatible with OpenSSH, so it could be messy to support. Anyways, this works for now, but Apple will probably stop shipping OpenSSH in future releases.

http://stackoverflow.com/questions/7406946/why-is-apple-depricating-openssl-in-macos-10-7-lion
