### PR TITLE
Facebook auth

### DIFF
--- a/ebin/Makefile.am
+++ b/ebin/Makefile.am
@@ -43,6 +43,7 @@ BEAM_FILES = exmpp.app							\
 	     exmpp_server_session.beam					\
 	     exmpp_server_tls.beam					\
 	     exmpp_sasl_digest.beam					\
+	     exmpp_sasl_facebook.beam					\
 	     exmpp_session.beam						\
 	     exmpp_socket.beam						\
 	     exmpp_bosh.beam						\

--- a/ebin/exmpp.app.in
+++ b/ebin/exmpp.app.in
@@ -42,6 +42,7 @@
         exmpp_server_session,
         exmpp_server_tls,
         exmpp_sasl_digest,
+        exmpp_sasl_facebook,
         exmpp_session,
         exmpp_socket@COMPAT_MODULES_START@
         @COMPAT_MODULES@ejabberd_socket,

--- a/src/Emakefile.in
+++ b/src/Emakefile.in
@@ -26,6 +26,7 @@
 		'@srcdir@/network/exmpp_bosh',
 		'@srcdir@/network/exmpp_component',
 		'@srcdir@/network/exmpp_sasl_digest',
+		'@srcdir@/network/exmpp_sasl_facebook',
 		'@srcdir@/client/exmpp_client_binding',
 		'@srcdir@/client/exmpp_client_compression',
 		'@srcdir@/client/exmpp_client_disco',

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = core/exmpp.erl						\
 	     network/exmpp_component.erl				\
 	     network/exmpp_dns.erl					\
 	     network/exmpp_sasl_digest.erl					\
+	     network/exmpp_sasl_facebook.erl					\
 	     client/exmpp_client_binding.erl				\
 	     client/exmpp_client_compression.erl			\
 	     client/exmpp_client_disco.erl			\

--- a/src/network/exmpp_sasl_facebook.erl
+++ b/src/network/exmpp_sasl_facebook.erl
@@ -1,0 +1,76 @@
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+
+-module(exmpp_sasl_facebook).
+
+-export([
+	 mech_client_new/2,
+	 mech_step/2]).
+
+
+%% @type mechstate() = {state, Step, AccessToken, AppId}
+%%     Step = 1 | 2
+%%     AccessToken = string()
+%%     AppId = string()
+
+-record(state, {step, access_token, app_id}).
+
+mech_client_new(AccessToken, AppId) ->
+    {ok, #state{step = 1,
+                access_token = AccessToken,
+                app_id = AppId
+		}}.
+
+%% @spec (State, ClientIn) -> Ok | Continue | Error
+%%     State = mechstate()
+%%     ClientIn = string()
+%%     Ok = {ok, Props}
+%%         Props = [Prop]
+%%         Prop = {nonce, Nonce} | {method, Method}
+%%         Nonce = string()
+%%         Method = string()
+%%     Continue = {continue, ServerOut, New_State}
+%%         ServerOut = string()
+%%         New_State = mechstate()
+%%     Error = {error, Reason} | {error, Reason}
+%%         Reason = term()
+
+mech_step(#state{step = 1, access_token = AccessToken, app_id = AppId} = State, ServerOut) ->
+    case parse(ServerOut) of
+        bad ->
+            {error, 'bad-protocol'};
+        KeyVals ->
+            Nonce = proplists:get_value("nonce", KeyVals),
+            Method = proplists:get_value("method", KeyVals),
+            {continue,
+             "method=\"" ++ Method ++ "\",nonce=\"" ++ Nonce ++
+                 ",access_token=\"" ++ AccessToken ++"\"" ++
+                 ",api_key=\"" ++ AppId ++"\"" ++
+                 ",call_id=\"0\"" ++ ",v=\"0.1\"",
+             State#state{step = 2}}
+    end;
+mech_step(#state{step = 2}, ServerOut) ->
+    io:format("sout: ~p~n", [ServerOut]),
+    {ok, []};
+mech_step(_A, _B) ->
+    {error, 'bad-protocol'}.
+
+%% @spec (S) -> [{Key, Value}] | bad
+%%     S = string()
+%%     Key = string()
+%%     Value = string()
+
+parse(S) ->
+    try
+        [list_to_tuple(string:tokens(Pair, "=")) || Pair <- string:tokens(S, "&")]
+    catch
+        _Class:_Error -> bad
+    end.

--- a/src/network/exmpp_sasl_facebook.erl
+++ b/src/network/exmpp_sasl_facebook.erl
@@ -50,11 +50,14 @@ mech_step(#state{step = 1, access_token = AccessToken, app_id = AppId} = State, 
         KeyVals ->
             Nonce = proplists:get_value("nonce", KeyVals),
             Method = proplists:get_value("method", KeyVals),
+            CallId = integer_to_list(element(2, now())),
             {continue,
-             "method=\"" ++ Method ++ "\",nonce=\"" ++ Nonce ++
-                 ",access_token=\"" ++ AccessToken ++"\"" ++
-                 ",api_key=\"" ++ AppId ++"\"" ++
-                 ",call_id=\"0\"" ++ ",v=\"0.1\"",
+             string:join(["method=" ++ Method,
+                          "api_key=" ++ AppId,
+                          "access_token=" ++ AccessToken,
+                          "call_id=" ++ CallId,
+                          "v=1.0",
+                          "nonce=" ++ Nonce], "&"),
              State#state{step = 2}}
     end;
 mech_step(#state{step = 2}, ServerOut) ->


### PR DESCRIPTION
This implements Facebook OAuth flow as per https://developers.facebook.com/docs/chat/

Usage example:

``` erlang
Session = exmpp_session:start_link({1, 0}),
JID = exmpp_jid:make("john.doe", "chat.facebook.com", random),
Token = "AAASOMETOKEN",
AppId = "1234567890",
exmpp_session:auth_info(Session, JID, Token, AppId),
Connect = exmpp_session:connect_TCP(Session, Domain, 5222, []),
exmpp_session:login(Session, "X-FACEBOOK-PLATFORM"),
```
