### PR TITLE
Hash functions from `crypto` Erlang core module

### DIFF
--- a/src/client/exmpp_client_legacy_auth.erl
+++ b/src/client/exmpp_client_legacy_auth.erl
@@ -365,7 +365,7 @@ is_success(IQ) when ?IS_IQ(IQ) ->
 digest(ID, Passwd) ->
     Token = ID ++ Passwd,
     crypto:start(),
-    binary_to_list(crypto:sha(Token)).
+    binary_to_list(crypto:hash(sha, Token)).
 
 %% @spec (Plain) -> Hex
 %%     Plain = string()

--- a/src/core/exmpp_caps.erl
+++ b/src/core/exmpp_caps.erl
@@ -218,6 +218,6 @@ identities(_) ->
 -spec(hash_caps/1 :: (string()) -> hash()).
 
 hash_caps(String) when is_list(String)->
-    base64:encode(crypto:sha(unicode:characters_to_list(String)));
+    base64:encode(crypto:hash(sha, unicode:characters_to_list(String)));
 hash_caps(_) ->
     throw({exmpp_caps, hash_caps, 'String : string()'}).

--- a/src/network/exmpp_sasl_digest.erl
+++ b/src/network/exmpp_sasl_digest.erl
@@ -300,11 +300,11 @@ response(KeyVals, User, Passwd, Nonce, AuthzId, A2Prefix) ->
     A1 = case AuthzId of
 	     "" ->
 		 binary_to_list(
-		   crypto:md5(User ++ ":" ++ Realm ++ ":" ++ Passwd)) ++
+		   crypto:hash(md5, User ++ ":" ++ Realm ++ ":" ++ Passwd)) ++
 		     ":" ++ Nonce ++ ":" ++ CNonce;
 	     _ ->
 		 binary_to_list(
-		   crypto:md5(User ++ ":" ++ Realm ++ ":" ++ Passwd)) ++
+		   crypto:hash(md5, User ++ ":" ++ Realm ++ ":" ++ Passwd)) ++
 		     ":" ++ Nonce ++ ":" ++ CNonce ++ ":" ++ AuthzId
 	 end,
     A2 = case QOP of
@@ -314,8 +314,8 @@ response(KeyVals, User, Passwd, Nonce, AuthzId, A2Prefix) ->
 		 A2Prefix ++ ":" ++ DigestURI ++
 		     ":00000000000000000000000000000000"
 	 end,
-    T = hex(binary_to_list(crypto:md5(A1))) ++ ":" ++ Nonce ++ ":" ++
+    T = hex(binary_to_list(crypto:hash(md5, A1))) ++ ":" ++ Nonce ++ ":" ++
 	NC ++ ":" ++ CNonce ++ ":" ++ QOP ++ ":" ++
-	hex(binary_to_list(crypto:md5(A2))),
-    hex(binary_to_list(crypto:md5(T))).
+	hex(binary_to_list(crypto:hash(md5, A2))),
+    hex(binary_to_list(crypto:hash(md5, T))).
 


### PR DESCRIPTION
Due to deprecation of separate `md5/1`, `sha/1` and others, supposing usage single `hash/2` for that cases.
