### PR TITLE
Without this change you get the following error: comparison of unsign…

### DIFF
--- a/c_src/exmpp_tls_openssl.c
+++ b/c_src/exmpp_tls_openssl.c
@@ -441,7 +441,8 @@ exmpp_tls_openssl_control(ErlDrvData drv_data, unsigned int command,
 	case COMMAND_GET_PEER_CERTIFICATE:
 		/* Get the peer certificate. */
 		cert = SSL_get_peer_certificate(edd->ssl);
-		if (cert == NULL || (rlen = i2d_X509(cert, NULL)) < 0) {
+		int rlen = i2d_X509(cert, NULL);
+		if (cert == NULL || rlen < 0) {
 			to_send = exmpp_new_xbuf();
 			if (to_send == NULL)
 				return (-1);


### PR DESCRIPTION
…ed expression < 0 is alway

due to the Wtautological-compare compile flag
