### PR TITLE
Fix obsolete spec syntax for otp 19 and  C compile warning.

### DIFF
--- a/c_src/exmpp_tls_openssl.c
+++ b/c_src/exmpp_tls_openssl.c
@@ -441,7 +441,8 @@ exmpp_tls_openssl_control(ErlDrvData drv_data, unsigned int command,
 	case COMMAND_GET_PEER_CERTIFICATE:
 		/* Get the peer certificate. */
 		cert = SSL_get_peer_certificate(edd->ssl);
-		if (cert == NULL || (rlen = i2d_X509(cert, NULL)) < 0) {
+		rlen = i2d_X509(cert, NULL);
+		if (cert == NULL || i2d_X509(cert, NULL) < 0) {
 			to_send = exmpp_new_xbuf();
 			if (to_send == NULL)
 				return (-1);

--- a/src/core/exmpp_caps.erl
+++ b/src/core/exmpp_caps.erl
@@ -52,7 +52,7 @@
 %%     Hash = hash()
 %% @doc Generate a hash from a Caps record.
 
--spec(make/1 :: (ecaps() | identity() | [identity()]) -> hash()).
+-spec( make (ecaps() | identity() | [identity()]) -> hash()).
 
 make(#identity{} = Identity) ->
     make(Identity, []);
@@ -77,7 +77,7 @@ make(_) ->
 %% @doc Generate a hash from an identity record or from a list of records
 %%      and a list of namespaces .
 
--spec(make/2 :: (identity() | [identity()], [ns()]) -> hash()).
+-spec(make(identity() | [identity()], [ns()]) -> hash()).
 
 make(_, Features) when not is_list(Features) ->
     throw({exmpp_caps, make, 'Features : [ns()]'});
@@ -103,7 +103,7 @@ make(Identities, Features) ->
 %% @doc Generate a hash from an identity record or from a list of identity records,
 %%      a list of namespaces, and a form or a list of forms .
 
--spec(make/3 :: (identity() | [identity()], [ns()], form() | [form()]) -> hash()).
+-spec(make(identity() | [identity()], [ns()], form() | [form()]) -> hash()).
 
 make(_, Features, _) when not is_list(Features) ->
     throw({exmpp_caps, make, 'Features : [ns()]'});
@@ -135,7 +135,7 @@ make(Identities, Features, Forms) ->
 %%     Forms  = form()  | [form()]
 %%     String = string()
 
--spec(forms/1 :: (form()  | [form()]) -> string()).
+-spec(forms(form()  | [form()]) -> string()).
 
 forms(#form{type = Type, fields = Fields}) ->
     Type ++ "<" ++ fields(Fields);
@@ -151,7 +151,7 @@ forms(_) ->
 %%     Fields = field() | [field()]
 %%     String = string()
 
--spec(fields/1 :: (field()  | [field()]) -> string()).
+-spec(fields(field()  | [field()]) -> string()).
 
 fields(#field{var = Var, values = Values}) ->
     Var ++ "<" ++ values(Values);
@@ -167,7 +167,7 @@ fields(_) ->
 %%     Values = [value()]
 %%     String = string()
 
--spec(values/1 :: ([value()]) -> string()).
+-spec(values([value()]) -> string()).
 
 values(Values) when is_list(Values) ->
     lists:foldl(
@@ -187,7 +187,7 @@ values(_) ->
 %%     Features = [ns()]
 %%     String   = string()
 
--spec(features/1 :: ([ns()]) -> string()).
+-spec(features([ns()]) -> string()).
 
 features(Features) when is_list(Features) ->
     values(Features);
@@ -199,7 +199,7 @@ features(_) ->
 %%     Identities = identity() | [identity()]
 %%     String     = string()
 
--spec(identities/1 :: (identity() | [identity()]) -> string()).
+-spec(identities(identity() | [identity()]) -> string()).
 
 identities(#identity{category = Category, type = Type, lang = Lang, name = Name}) ->
     Category ++ "/" ++ Type ++ "/" ++ Lang ++ "/" ++ Name ++ "<";
@@ -215,7 +215,7 @@ identities(_) ->
 %%     String = string()
 %%     Hash   = hash()
 
--spec(hash_caps/1 :: (string()) -> hash()).
+-spec(hash_caps (string()) -> hash()).
 
 hash_caps(String) when is_list(String)->
     base64:encode(crypto:sha(unicode:characters_to_list(String)));

--- a/src/core/exmpp_internals.erl
+++ b/src/core/exmpp_internals.erl
@@ -49,7 +49,7 @@
 %%     Dirs = [string()]
 %% @doc Return a list of directories to search port drivers in.
 
--spec(driver_dirs/0 :: () -> [string()]).
+-spec(driver_dirs() -> [string()]).
 
 driver_dirs() ->
     Mod_Path = case code:is_loaded(?MODULE) of
@@ -85,7 +85,7 @@ driver_dirs() ->
 %% @throws {port_driver, load, Reason, Driver_Name}
 %% @doc Load the port driver `Driver_Name'.
 
--spec(load_driver/1 :: (atom()) -> ok).
+-spec(load_driver(atom()) -> ok).
 
 load_driver(Driver_Name) ->
     Dirs = driver_dirs(),
@@ -99,7 +99,7 @@ load_driver(Driver_Name) ->
 %%
 %% The driver is search in `Dirs'.
 
--spec(load_driver/2 :: (atom(), [string()]) -> ok).
+-spec(load_driver(atom(), [string()]) -> ok).
 
 load_driver(Driver_Name, Dirs) ->
     load_driver1(Driver_Name, Dirs, undefined).
@@ -121,7 +121,7 @@ load_driver1(Driver_Name, [], Reason) ->
 %%     Driver_Name = atom()
 %% @doc Unload the port driver `Driver_Name'.
 
--spec(unload_driver/1 :: (atom()) -> ok).
+-spec(unload_driver(atom()) -> ok).
 
 unload_driver(Driver_Name) ->
     erl_ddll:unload_driver(Driver_Name),
@@ -133,7 +133,7 @@ unload_driver(Driver_Name) ->
 %% @throws {port_driver, open, {posix, Posix_Code}, Driver_Name}
 %% @doc Spawn a new port driver instance.
 
--spec(open_port/1 :: (atom()) -> port()).
+-spec(open_port(atom()) -> port()).
 
 open_port(Driver_Name) ->
     try
@@ -149,7 +149,7 @@ open_port(Driver_Name) ->
 %%
 %% `Port' was obtained with {@link open_port/1}.
 
--spec(close_port/1 :: (port()) -> true).
+-spec(close_port(port()) -> true).
 
 close_port(Port) ->
     erlang:port_close(Port).
@@ -168,8 +168,7 @@ close_port(Port) ->
 %% @doc Wrapper to abstract the `recv' function of multiple communication
 %% modules.
 
--spec(gen_recv/2 ::
-      ({atom(), any()}, integer() | infinity) -> {ok, binary()} | {error, any()}).
+-spec(gen_recv({atom(), any()}, integer() | infinity) -> {ok, binary()} | {error, any()}).
 
 gen_recv({gen_tcp, Socket}, Timeout) ->
     gen_tcp:recv(Socket, 0, Timeout);
@@ -185,7 +184,7 @@ gen_recv({Mod, Socket}, Timeout) ->
 %% @doc Wrapper to abstract the `send' function of multiple communication
 %% modules.
 
--spec(gen_send/2 :: ({atom(), any()}, binary()) -> ok | {error, any()}).
+-spec(gen_send({atom(), any()}, binary()) -> ok | {error, any()}).
 
 gen_send({Mod, Socket}, Packet) ->
     Mod:send(Socket, Packet).
@@ -199,7 +198,7 @@ gen_send({Mod, Socket}, Packet) ->
 %% @doc Wrapper to abstract the `getopts' function of multiple communication
 %% modules.
 
--spec(gen_getopts/2 :: ({atom(), any()}, list()) -> list() | {error, any()}).
+-spec(gen_getopts({atom(), any()}, list()) -> list() | {error, any()}).
 
 gen_getopts({gen_tcp, Socket}, Options) ->
     inet:getopts(Socket, Options);
@@ -214,7 +213,7 @@ gen_getopts({Mod, Socket}, Options) ->
 %% @doc Wrapper to abstract the `setopts' function of multiple communication
 %% modules.
 
--spec(gen_setopts/2 :: ({atom(), any()}, list()) -> ok | {error, any()}).
+-spec(gen_setopts({atom(), any()}, list()) -> ok | {error, any()}).
 
 gen_setopts({gen_tcp, Socket}, Options) ->
     inet:setopts(Socket, Options);
@@ -230,7 +229,7 @@ gen_setopts({Mod, Socket}, Options) ->
 %% @doc Wrapper to abstract the `peername' function of multiple communication
 %% modules.
 
--spec(gen_peername/1 :: ({atom(), any()}) -> {ok, any()} | {error, any()}).
+-spec(gen_peername({atom(), any()}) -> {ok, any()} | {error, any()}).
 
 gen_peername({gen_tcp, Socket}) ->
     inet:peername(Socket);
@@ -246,7 +245,7 @@ gen_peername({Mod, Socket}) ->
 %% @doc Wrapper to abstract the `sockname' function of multiple communication
 %% modules.
 
--spec(gen_sockname/1 :: ({atom(), any()}) -> {ok, any()} | {error, any()}).
+-spec(gen_sockname({atom(), any()}) -> {ok, any()} | {error, any()}).
 
 gen_sockname({gen_tcp, Socket}) ->
     inet:sockname(Socket);
@@ -262,8 +261,7 @@ gen_sockname({Mod, Socket}) ->
 %% @doc Wrapper to abstract the `controlling_process' function of
 %% multiple communication modules.
 
--spec(gen_controlling_process/2 ::
-      ({atom(), any()}, pid()) -> ok | {error, any()}).
+-spec(gen_controlling_process({atom(), any()}, pid()) -> ok | {error, any()}).
 
 gen_controlling_process({Mod, Socket}, Pid) ->
     Mod:controlling_process(Socket, Pid).
@@ -275,7 +273,7 @@ gen_controlling_process({Mod, Socket}, Pid) ->
 %% @doc Wrapper to abstract the `close' function of multiple communication
 %% modules.
 
--spec(gen_close/1 :: ({atom(), any()}) -> ok | {error, any()}).
+-spec(gen_close({atom(), any()}) -> ok | {error, any()}).
 
 gen_close({Mod, Socket}) ->
     Mod:close(Socket).

--- a/src/core/exmpp_iq.erl
+++ b/src/core/exmpp_iq.erl
@@ -90,7 +90,7 @@
 %%     IQ = exmpp_xml:xmlel()
 %% @doc Prepare an `<iq/>' to transport the given `get' request.
 
--spec(get/2 :: (xmlname(), #xmlel{}) -> #xmlel{}).
+-spec(get (xmlname(), #xmlel{}) -> #xmlel{}).
 
 get(NS, Request) ->
     get(NS, Request, random).
@@ -102,7 +102,7 @@ get(NS, Request) ->
 %%     Request_IQ = exmpp_xml:xmlel()
 %% @doc Prepare an `<iq/>' to transport the given `get' request.
 
--spec(get/3 ::
+-spec(get
       (xmlname(), #xmlel{}, binary() | string() | random) -> #xmlel{}).
 
 get(NS, Request, ID) ->
@@ -120,7 +120,7 @@ get(NS, Request, ID) ->
 %%     Request_IQ = exmpp_xml:xmlel()
 %% @doc Prepare an `<iq/>' to transport the given `set' request.
 
--spec(set/2 :: (xmlname(), #xmlel{}) -> #xmlel{}).
+-spec(set (xmlname(), #xmlel{}) -> #xmlel{}).
 
 set(NS, Request) ->
     set(NS, Request, random).
@@ -132,7 +132,7 @@ set(NS, Request) ->
 %%     Request_IQ = exmpp_xml:xmlel()
 %% @doc Prepare an `<iq/>' to transport the given `set' request.
 
--spec(set/3 ::
+-spec(set
       (xmlname(), #xmlel{}, binary() | string() | random) -> #xmlel{}).
 
 set(NS, Request, ID) ->
@@ -149,7 +149,7 @@ set(NS, Request, ID) ->
 %%     Response_IQ = exmpp_xml:xmlel() | iq()
 %% @doc Prepare an `<iq/>' to answer to the given request.
 
--spec(result/1 :: (#xmlel{} | #iq{}) -> #xmlel{} | #iq{}).
+-spec(result (#xmlel{} | #iq{}) -> #xmlel{} | #iq{}).
 
 result(Request_IQ) when ?IS_IQ(Request_IQ) ->
     Attrs1 = exmpp_stanza:reply_from_attrs(Request_IQ#xmlel.attrs),
@@ -171,7 +171,7 @@ result(Request_IQ_Rec) when ?IS_IQ_RECORD(Request_IQ_Rec) ->
 %%     Response_IQ = exmpp_xml:xmlel() | iq()
 %% @doc Prepare an `<iq/>' to answer to the given request with `Result'.
 
--spec(result/2 :: (#xmlel{} | #iq{}, #xmlel{}) -> #xmlel{} | #iq{}).
+-spec(result (#xmlel{} | #iq{}, #xmlel{}) -> #xmlel{} | #iq{}).
 
 result(Request_IQ, Result) when ?IS_IQ(Request_IQ) ->
     exmpp_xml:set_children(result(Request_IQ), [Result]);
@@ -188,7 +188,7 @@ result(Request_IQ_Rec, Result) when ?IS_IQ_RECORD(Request_IQ_Rec) ->
 %% If `Error' is an atom, it must be a standard condition defined by
 %% XMPP Core.
 
--spec(error/2 ::
+-spec(error
       (#xmlel{} | #iq{}, #xmlel{} | atom()) -> #xmlel{} | #iq{}).
 
 error(IQ, Condition)
@@ -217,7 +217,7 @@ error(IQ_Rec, Error) when ?IS_IQ_RECORD(IQ_Rec) ->
 %% If `Error' is an atom, it must be a standard condition defined by
 %% XMPP Core.
 
--spec(error/3 ::
+-spec(error
 (
   Request_IQ :: #xmlel{} | #iq{},
   Condition  :: atom(),
@@ -245,7 +245,7 @@ error(IQ_Rec, Condition, Text)
 %% If `Error' is an atom, it must be a standard condition defined by
 %% XMPP Core.
 
--spec(error_without_original/2 ::
+-spec(error_without_original
       (#xmlel{} | #iq{}, #xmlel{} | atom()) -> #xmlel{} | #iq{}).
 
 error_without_original(IQ, Condition) when is_atom(Condition) ->
@@ -269,7 +269,7 @@ error_without_original(IQ_Rec, Error) when ?IS_IQ_RECORD(IQ_Rec) ->
 %%     IQ_Rec = iq()
 %% @doc Convert an IQ stanza from its #xmlel form to its #iq form.
 
--spec(xmlel_to_iq/1 :: (#xmlel{}) -> #iq{}).
+-spec(xmlel_to_iq (#xmlel{}) -> #iq{}).
 
 xmlel_to_iq(#xmlel{ns = IQ_NS} = IQ) when ?IS_IQ(IQ) ->
     Kind = get_kind(IQ),
@@ -305,7 +305,7 @@ xmlel_to_iq(#xmlel{ns = IQ_NS} = IQ) when ?IS_IQ(IQ) ->
 %%     IQ = exmpp_xml:xmlel()
 %% @doc Convert an IQ stanza from its #iq form to its #xmlel form.
 
--spec(iq_to_xmlel/1 :: (#iq{}) -> #xmlel{}).
+-spec(iq_to_xmlel (#iq{}) -> #xmlel{}).
 
 iq_to_xmlel(IQ_Rec) when ?IS_IQ_RECORD(IQ_Rec) ->
     iq_to_xmlel2(IQ_Rec, []).
@@ -318,7 +318,7 @@ iq_to_xmlel(IQ_Rec) when ?IS_IQ_RECORD(IQ_Rec) ->
 %% @doc Convert an IQ stanza from its #iq form to its #xmlel form and
 %% set the sender and recipient at the same time.
 
--spec(iq_to_xmlel/3 ::
+-spec(iq_to_xmlel
       (#iq{}, exmpp_stanza:jidlike(), exmpp_stanza:jidlike()) -> #xmlel{}).
 
 iq_to_xmlel(IQ_Rec, Sender, Recipient) when ?IS_IQ_RECORD(IQ_Rec) ->
@@ -354,7 +354,7 @@ iq_to_xmlel2(#iq{type = Type, id = ID, lang = Lang, payload = Payload,
 %%
 %% You should probably use the `IS_IQ(El)' guard expression.
 
--spec(is_iq/1 :: (#xmlel{}) -> bool()).
+-spec(is_iq (#xmlel{}) -> bool()).
 
 is_iq(IQ) when ?IS_IQ(IQ) -> true;
 is_iq(_El)                -> false.
@@ -365,7 +365,7 @@ is_iq(_El)                -> false.
 %%
 %% You should probably use the `IS_IQ_RECORD(El)' guard expression.
 
--spec(is_iq_record/1 :: (#iq{}) -> bool()).
+-spec(is_iq_record (#iq{}) -> bool()).
 
 is_iq_record(IQ) when ?IS_IQ_RECORD(IQ) -> true;
 is_iq_record(_El)                       -> false.
@@ -375,7 +375,7 @@ is_iq_record(_El)                       -> false.
 %%     Type = get | set | result | error | undefined
 %% @doc Return the type of the given `<iq/>'.
 
--spec(get_type/1 ::
+-spec(get_type
       (#xmlel{} | #iq{}) -> get | set | result | error | undefined).
 
 get_type(IQ) when ?IS_IQ(IQ) ->
@@ -394,7 +394,7 @@ get_type(#iq{type = Type}) ->
 %%     Kind = request | response | undefined
 %% @doc Tell if an IQ is a request or a response.
 
--spec(get_kind/1 ::
+-spec(get_kind
       (#xmlel{} | #iq{}) -> request | response | undefined).
 
 get_kind(IQ) when ?IS_IQ(IQ) ->
@@ -412,7 +412,7 @@ get_kind(#iq{kind = Kind}) ->
 %%     IQ = exmpp_xml:xmlel() | iq()
 %% @doc Tell if the IQ is a request.
 
--spec(is_request/1 :: (#xmlel{} | #iq{}) -> bool()).
+-spec(is_request (#xmlel{} | #iq{}) -> bool()).
 
 is_request(IQ) when ?IS_IQ(IQ) ->
     case get_kind(IQ) of
@@ -426,7 +426,7 @@ is_request(#iq{kind = Kind}) ->
 %%     IQ = exmpp_xml:xmlel() | iq()
 %% @doc Tell if the IQ is a response.
 
--spec(is_response/1 :: (#xmlel{} | #iq{}) -> bool()).
+-spec(is_response (#xmlel{} | #iq{}) -> bool()).
 
 is_response(IQ) when ?IS_IQ(IQ) ->
     case get_kind(IQ) of
@@ -440,7 +440,7 @@ is_response(#iq{kind = Kind}) ->
 %%     IQ = exmpp_xml:xmlel() | iq()
 %% @doc Tell if the IQ is a result (response of type `result').
 
--spec(is_result/1 :: (#xmlel{} | #iq{}) -> bool()).
+-spec(is_result (#xmlel{} | #iq{}) -> bool()).
 
 is_result(IQ) when ?IS_IQ(IQ) ->
     case get_type(IQ) of
@@ -454,7 +454,7 @@ is_result(#iq{type = Type}) ->
 %%     IQ = exmpp_xml:xmlel() | iq()
 %% @doc Tell if the IQ is an error (response of type `error').
 
--spec(is_error/1 :: (#xmlel{} | #iq{}) -> bool()).
+-spec(is_error (#xmlel{} | #iq{}) -> bool()).
 
 is_error(IQ) when ?IS_IQ(IQ) ->
     case get_type(IQ) of
@@ -472,7 +472,7 @@ is_error(#iq{type = Type}) ->
 %% @doc Return the request contained in a `get' or `set' IQ, or returned
 %% by an `error' IQ (if present).
 
--spec(get_request/1 :: (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
+-spec(get_request (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
 
 get_request(IQ) when ?IS_IQ(IQ) ->
     case get_type(IQ) of
@@ -513,7 +513,7 @@ get_request(#iq{} = IQ_Rec) ->
 %%         {iq, get_result, invalid_iq, IQ}
 %% @doc Return the result contained in a `result' IQ.
 
--spec(get_result/1 :: (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
+-spec(get_result (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
 
 get_result(IQ) when ?IS_IQ(IQ) ->
     case get_type(IQ) of
@@ -540,7 +540,7 @@ get_result(#iq{} = IQ_Rec) ->
 %% @throws {iq, get_payload, unexpected_iq, IQ}
 %% @doc Extract the request, the result or the error from `IQ'.
 
--spec(get_payload/1 :: (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
+-spec(get_payload (#xmlel{} | #iq{}) -> #xmlel{} | undefined).
 
 get_payload(IQ) ->
     case exmpp_iq:get_type(IQ) of

--- a/src/core/exmpp_jid.erl
+++ b/src/core/exmpp_jid.erl
@@ -151,7 +151,7 @@ to_lower(StringJid) when is_binary(StringJid)->
 %%     Jid = jid()
 %% @doc Create a blank JID.
 
--spec(make/0 :: () -> jid()).
+-spec(make () -> jid()).
 
 make() ->
     #jid{}.
@@ -163,7 +163,7 @@ make() ->
 %%         {jid, make, invalid,  {domain, Domain}}
 %% @doc Create a bare JID.
 
--spec(make/1 :: (domain_arg() | {node_arg(), domain_arg(), res_arg()}) -> jid()).
+-spec(make (domain_arg() | {node_arg(), domain_arg(), res_arg()}) -> jid()).
 make({Node, Domain, Resource})->
     make(Node, Domain, Resource);
 make(Domain) ->
@@ -179,7 +179,7 @@ make(Domain) ->
 %%         {jid, make, invalid,  {node, Node}}
 %% @doc Create a bare JID.
 
--spec(make/2 :: (node_arg(), domain_arg()) -> jid()).
+-spec(make (node_arg(), domain_arg()) -> jid()).
 
 make(_Node, Domain)
   when is_list(Domain), length(Domain) > ?DOMAIN_MAX_LENGTH ->
@@ -239,7 +239,7 @@ make(Node, Domain) ->
 %%     Jid = jid()
 %% @doc Create a full JID.
 
--spec(make/3 :: (node_arg(), domain_arg(), res_arg()) -> jid()).
+-spec(make (node_arg(), domain_arg(), res_arg()) -> jid()).
 
 make(Node, Domain, undefined) ->
     make(Node, Domain);
@@ -273,7 +273,7 @@ make(Node, Domain, Resource) ->
 %% We reuse this value here. The intention is to save some memory, see
 %% comments on `include/internal/exmpp_xmpp.hrl'
 
--spec(make/4 :: (binary(), node_arg(), domain_arg(), res_arg()) -> jid()).
+-spec(make (binary(), node_arg(), domain_arg(), res_arg()) -> jid()).
 
 make(Orig, Node, Domain, Resource) ->
     try
@@ -307,7 +307,7 @@ make(Orig, Node, Domain, Resource) ->
 %%     Bare_Jid = jid()
 %% @doc Convert a full JID to its bare version.
 
--spec(bare/1 :: (jid()) -> jid()).
+-spec(bare (jid()) -> jid()).
 
 bare(#jid{raw = Orig_Jid} = Jid) ->
     New_Orig_Jid = case binary_split(Orig_Jid, $/) of
@@ -327,7 +327,7 @@ bare(#jid{raw = Orig_Jid} = Jid) ->
 %%         {jid, convert, invalid,  {resource, Resource}}
 %% @doc Convert a bare JID to its full version.
 
--spec(full/2 :: (jid(), res_arg()) -> jid()).
+-spec(full (jid(), res_arg()) -> jid()).
 
 full(Jid, undefined) ->
     Jid;
@@ -375,7 +375,7 @@ full(#jid{raw = Orig_Jid} = Jid, Resource) ->
 %% @throws {jid, parse, Reason, {jid, String}}
 %% @doc Parse a string and create a full JID.
 
--spec(parse/1 :: (binary() | string()) -> jid()).
+-spec(parse (binary() | string()) -> jid()).
 
 parse(String) when is_binary(String) ->
     case parse_binary(String, String, <<>>) of
@@ -393,7 +393,7 @@ parse(String) when is_list(String) ->
             Jid
     end.
 
--spec(parse_binary/3 :: (binary(), binary(), binary()) -> jid() | {error, any()}).
+-spec(parse_binary (binary(), binary(), binary()) -> jid() | {error, any()}).
 
 parse_binary(_Original, String, _) when size(String) > ?JID_MAX_LENGTH ->
     %% Invalid JID: too long.
@@ -453,7 +453,7 @@ parse_binary(Original, <<>>, Node, Domain) ->
 %%     String = string()
 %% @doc Stringify a full JID.
 
--spec(to_list/1 :: (jid()) -> string()).
+-spec(to_list (jid()) -> string()).
 
 to_list(#jid{} = JID) ->
     binary_to_list(to_binary(JID)).
@@ -464,7 +464,7 @@ to_list(#jid{} = JID) ->
 %%     String = string()
 %% @doc Stringify a bare JID.
 
--spec(to_list/2 :: (node_arg(), domain_arg()) -> string()).
+-spec(to_list (node_arg(), domain_arg()) -> string()).
 
 to_list(Node, Domain) ->
     bare_to_list(Node, Domain).
@@ -476,7 +476,7 @@ to_list(Node, Domain) ->
 %%     String = string()
 %% @doc Stringify a full JID.
 
--spec(to_list/3 :: (node_arg(), domain_arg(), res_arg()) -> string()).
+-spec(to_list (node_arg(), domain_arg(), res_arg()) -> string()).
 
 to_list(Node, Domain, Resource) ->
     binary_to_list(to_binary(Node, Domain, Resource)).
@@ -486,7 +486,7 @@ to_list(Node, Domain, Resource) ->
 %%     String = string()
 %% @doc Stringify a full JID with STRINGPREP profiles applied.
 
--spec(prep_to_list/1 :: (jid()) -> string()).
+-spec(prep_to_list (jid()) -> string()).
 
 prep_to_list(
   #jid{node = Node, domain = Domain, resource = Resource}) ->
@@ -497,7 +497,7 @@ prep_to_list(
 %%     String = string()
 %% @doc Stringify a bare JID.
 
--spec(bare_to_list/1 :: (jid()) -> string()).
+-spec(bare_to_list (jid()) -> string()).
 
 bare_to_list(#jid{} = JID) ->
     binary_to_list(bare_to_binary(JID)).
@@ -508,7 +508,7 @@ bare_to_list(#jid{} = JID) ->
 %%     String = string()
 %% @doc Stringify a full JID.
 
--spec(bare_to_list/2 :: (node_arg(), domain_arg()) -> string()).
+-spec(bare_to_list (node_arg(), domain_arg()) -> string()).
 
 bare_to_list(Node, Domain) ->
     binary_to_list(bare_to_binary(Node, Domain)).
@@ -518,7 +518,7 @@ bare_to_list(Node, Domain) ->
 %%     String = string()
 %% @doc Stringify a bare JID with STRINGPREP profiles applied.
 
--spec(prep_bare_to_list/1 :: (jid()) -> string()).
+-spec(prep_bare_to_list (jid()) -> string()).
 
 prep_bare_to_list(
   #jid{node = Node, domain = Domain}) ->
@@ -529,7 +529,7 @@ prep_bare_to_list(
 %%     String = binary()
 %% @doc Stringify a full JID.
 
--spec(to_binary/1 :: (jid()) -> binary()).
+-spec(to_binary (jid()) -> binary()).
 
 to_binary(#jid{raw = Orig_Jid}) ->
     Orig_Jid.
@@ -540,7 +540,7 @@ to_binary(#jid{raw = Orig_Jid}) ->
 %%     String = binary()
 %% @doc Stringify a bare JID.
 
--spec(to_binary/2 :: (node_arg(), domain_arg()) -> binary()).
+-spec(to_binary (node_arg(), domain_arg()) -> binary()).
 
 to_binary(Node, Domain) ->
     bare_to_binary(Node, Domain).
@@ -552,7 +552,7 @@ to_binary(Node, Domain) ->
 %%     String = binary()
 %% @doc Stringify a full JID.
 
--spec(to_binary/3 :: (node_arg(), domain_arg(), res_arg()) -> binary()).
+-spec(to_binary (node_arg(), domain_arg(), res_arg()) -> binary()).
 
 to_binary(Node, Domain, Resource) when is_list(Resource) ->
     to_binary(Node, Domain, as_binary(Resource));
@@ -572,7 +572,7 @@ to_binary(Node, Domain, Resource)
 %%     String = binary()
 %% @doc Stringify a full JID with STRINGPREP profiles applied.
 
--spec(prep_to_binary/1 :: (jid()) -> binary()).
+-spec(prep_to_binary (jid()) -> binary()).
 
 prep_to_binary(
   #jid{node = Node, domain = Domain, resource = Resource}) ->
@@ -583,7 +583,7 @@ prep_to_binary(
 %%     String = binary()
 %% @doc Stringify a bare JID.
 
--spec(bare_to_binary/1 :: (jid()) -> binary()).
+-spec(bare_to_binary (jid()) -> binary()).
 
 bare_to_binary(#jid{raw = Orig_Jid, resource = LResource} = Jid) ->
     case LResource of
@@ -597,7 +597,7 @@ bare_to_binary(#jid{raw = Orig_Jid, resource = LResource} = Jid) ->
 %%     String = binary()
 %% @doc Stringify a full JID.
 
--spec(bare_to_binary/2 :: (node_arg(), domain_arg()) -> binary()).
+-spec(bare_to_binary (node_arg(), domain_arg()) -> binary()).
 
 bare_to_binary(Node, Domain) when is_list(Node) ->
     bare_to_binary(as_binary(Node), Domain);
@@ -619,7 +619,7 @@ bare_to_binary(Node, Domain)
 %%     String = binary()
 %% @doc Stringify a bare JID with STRINGPREP profiles applied.
 
--spec(prep_bare_to_binary/1 :: (jid()) -> binary()).
+-spec(prep_bare_to_binary (jid()) -> binary()).
 
 prep_bare_to_binary(#jid{node = Node, domain = Domain}) ->
     bare_to_binary(Node, Domain).
@@ -633,7 +633,7 @@ prep_bare_to_binary(#jid{node = Node, domain = Domain}) ->
 %%     Jid2 = jid()
 %% @doc Compare full JIDs.
 
--spec(full_compare/2 :: (jid(), jid()) -> bool()).
+-spec(full_compare (jid(), jid()) -> bool()).
 
 full_compare(#jid{node = LNode, domain = LDomain,
 		  resource = LResource},
@@ -648,7 +648,7 @@ full_compare(_Jid1, _Jid2) ->
 %%     Jid2 = jid()
 %% @doc Compare bare JIDs.
 
--spec(bare_compare/2 :: (jid(), jid()) -> bool()).
+-spec(bare_compare (jid(), jid()) -> bool()).
 
 bare_compare(#jid{node = LNode, domain = LDomain},
 	     #jid{node = LNode, domain = LDomain}) ->
@@ -661,7 +661,7 @@ bare_compare(_Jid1, _Jid2) ->
 %%     Jid2 = jid()
 %% @doc Compare full JIDs. This function is identical to full_compare/2.
 
--spec(compare/2 :: (jid(), jid()) -> bool()).
+-spec(compare (jid(), jid()) -> bool()).
 
 compare(Jid1, Jid2) ->
     full_compare(Jid1, Jid2).
@@ -671,7 +671,7 @@ compare(Jid1, Jid2) ->
 %%     Jid2 = jid()
 %% @doc Compare JID's domain.
 
--spec(compare_domains/2 :: (jid(), jid()) -> bool()).
+-spec(compare_domains (jid(), jid()) -> bool()).
 
 compare_domains(#jid{domain = LDomain},
 		#jid{domain = LDomain}) ->
@@ -689,7 +689,7 @@ compare_domains(_Jid1, _Jid2) ->
 %%
 %% You should probably use the `IS_JID(Jid)' guard expression.
 
--spec(is_jid/1 :: (jid()) -> bool()).
+-spec(is_jid (jid()) -> bool()).
 
 is_jid(Jid) when ?IS_JID(Jid) ->
     true;
@@ -705,7 +705,7 @@ is_jid(_) ->
 %%     Node = binary()
 %% @doc Return the node part of a JID.
 
--spec(node/1 :: (jid()) -> binary() | undefined).
+-spec(node (jid()) -> binary() | undefined).
 
 node(#jid{raw = undefined}) ->
     undefined;
@@ -720,7 +720,7 @@ node(#jid{raw = Orig_Jid}) ->
 %%     Node = binary()
 %% @doc Return the node part of a JID with NODEPREP profile applied.
 
--spec(prep_node/1 :: (jid()) -> binary() | undefined).
+-spec(prep_node (jid()) -> binary() | undefined).
 
 prep_node(#jid{node = N}) -> N.
 
@@ -729,7 +729,7 @@ prep_node(#jid{node = N}) -> N.
 %%     Domain = binary()
 %% @doc Return the domain part of a JID.
 
--spec(domain/1 :: (jid()) -> binary() | undefined).
+-spec(domain (jid()) -> binary() | undefined).
 
 domain(#jid{raw = undefined}) ->
     undefined;
@@ -748,7 +748,7 @@ domain(#jid{raw = Orig_Jid}) ->
 %%     Domain = binary()
 %% @doc Return the domain part of a JID with NAMEPREP profile applied.
 
--spec(prep_domain/1 :: (jid()) -> binary() | undefined).
+-spec(prep_domain (jid()) -> binary() | undefined).
 
 prep_domain(#jid{domain = D}) -> D.
 
@@ -757,7 +757,7 @@ prep_domain(#jid{domain = D}) -> D.
 %%     Resource = binary()
 %% @doc Return the resource part of a JID.
 
--spec(resource/1 :: (jid()) -> binary() | undefined).
+-spec(resource (jid()) -> binary() | undefined).
 
 resource(#jid{raw = undefined}) ->
     undefined;
@@ -772,7 +772,7 @@ resource(#jid{raw = Orig_Jid}) ->
 %%     Resource = binary()
 %% @doc Return the resource part of a JID with RESOURCEPREP profile applied.
 
--spec(prep_resource/1 :: (jid()) -> binary() | undefined).
+-spec(prep_resource (jid()) -> binary() | undefined).
 
 prep_resource(#jid{resource = R}) -> R.
 
@@ -781,7 +781,7 @@ prep_resource(#jid{resource = R}) -> R.
 %%     Node = string()
 %% @doc Return the node part of a JID as a list.
 
--spec(node_as_list/1 :: (jid()) -> string() | undefined).
+-spec(node_as_list (jid()) -> string() | undefined).
 
 node_as_list(Jid) ->
     as_list_or_undefined(exmpp_jid:node(Jid)).
@@ -792,7 +792,7 @@ node_as_list(Jid) ->
 %% @doc Return the node part of a JID as a list with NODEPREP profile
 %% applied.
 
--spec(prep_node_as_list/1 :: (jid()) -> string() | undefined).
+-spec(prep_node_as_list (jid()) -> string() | undefined).
 
 prep_node_as_list(Jid) ->
     as_list_or_undefined(prep_node(Jid)).
@@ -802,7 +802,7 @@ prep_node_as_list(Jid) ->
 %%     Domain = string()
 %% @doc Return the domain part of a JID as a list.
 
--spec(domain_as_list/1 :: (jid()) -> string() | undefined).
+-spec(domain_as_list (jid()) -> string() | undefined).
 
 domain_as_list(Jid) ->
     as_list_or_undefined(domain(Jid)).
@@ -813,7 +813,7 @@ domain_as_list(Jid) ->
 %% @doc Return the domain part of a JID as a list with NAMEPREP profile
 %% applied.
 
--spec(prep_domain_as_list/1 :: (jid()) -> string() | undefined).
+-spec(prep_domain_as_list (jid()) -> string() | undefined).
 
 prep_domain_as_list(Jid) ->
     as_list_or_undefined(prep_domain(Jid)).
@@ -823,7 +823,7 @@ prep_domain_as_list(Jid) ->
 %%     Resource = string()
 %% @doc Return the resource part of a JID as a list.
 
--spec(resource_as_list/1 :: (jid()) -> string() | undefined).
+-spec(resource_as_list (jid()) -> string() | undefined).
 
 resource_as_list(Jid) ->
     as_list_or_undefined(resource(Jid)).
@@ -834,7 +834,7 @@ resource_as_list(Jid) ->
 %% @doc Return the domain part of a JID as a list with RESOURCEPREP
 %% profile applied.
 
--spec(prep_resource_as_list/1 :: (jid()) -> string() | undefined).
+-spec(prep_resource_as_list (jid()) -> string() | undefined).
 
 prep_resource_as_list(Jid) ->
     as_list_or_undefined(prep_resource(Jid)).
@@ -854,7 +854,7 @@ as_binary(V) when is_list(V) ->
 %% We do not use random generator to avoid having to decide when and how
 %% to seed the Erlang random number generator.
 
--spec(generate_resource/0 :: () -> string()).
+-spec(generate_resource () -> string()).
 
 generate_resource() ->
     {A, B, C} = erlang:now(),
@@ -868,14 +868,14 @@ generate_resource() ->
 %% binary copies.
 %% "st or bi 2 bi" means: convert a STring OR a BInary TO a BInary.
 
--spec(storbi2bi/1 :: (binary() | string()) -> binary()).
+-spec(storbi2bi (binary() | string()) -> binary()).
 
 storbi2bi(String) when is_list(String) ->
     list_to_binary(String);
 storbi2bi(Binary) when is_binary(Binary) ->
     Binary.
 
--spec(binary_split/2 :: (binary(), char()) -> [binary()]).
+-spec(binary_split (binary(), char()) -> [binary()]).
 
 binary_split(B, C) -> binary_split(B, C, <<>>, []).
 

--- a/src/core/exmpp_stanza.erl
+++ b/src/core/exmpp_stanza.erl
@@ -116,7 +116,7 @@
 %% The error element is supposed to have the name `error' and the same
 %% namespace as the stanza.
 
--spec(get_error/1 :: (#xmlel{}) -> #xmlel{} | undefined).
+-spec(get_error (#xmlel{}) -> #xmlel{} | undefined).
 
 get_error(#xmlel{ns = NS} = Stanza) ->
     exmpp_xml:get_element(Stanza, NS, 'error');
@@ -137,7 +137,7 @@ get_error(#iq{}) ->
 %% The return value should be a JID and may be parsed with
 %% {@link exmpp_jid:parse/1}.
 
--spec(get_sender/1 :: (#xmlel{}) -> binary() | undefined).
+-spec(get_sender (#xmlel{}) -> binary() | undefined).
 
 get_sender(#xmlel{attrs = Attrs} = _Stanza) ->
     get_sender_from_attrs(Attrs).
@@ -150,7 +150,7 @@ get_sender(#xmlel{attrs = Attrs} = _Stanza) ->
 %% The return value should be a JID and may be parsed with
 %% {@link exmpp_jid:parse/1}.
 
--spec(get_sender_from_attrs/1 :: ([#xmlattr{}]) -> binary() | undefined).
+-spec(get_sender_from_attrs ([#xmlattr{}]) -> binary() | undefined).
 
 get_sender_from_attrs(Attrs) ->
     exmpp_xml:get_attribute_from_list_as_binary(Attrs, <<"from">>, undefined).
@@ -163,7 +163,7 @@ get_sender_from_attrs(Attrs) ->
 %%
 %% If `Sender' is set to `undefined', the sender is removed.
 
--spec(set_sender/2 ::
+-spec(set_sender
       (#xmlel{}, jidlike() | undefined) -> #xmlel{}).
 
 set_sender(#xmlel{attrs = Attrs} = Stanza, Sender) ->
@@ -178,7 +178,7 @@ set_sender(#xmlel{attrs = Attrs} = Stanza, Sender) ->
 %%
 %% If `Sender' is set to `undefined', the sender is removed.
 
--spec(set_sender_in_attrs/2 ::
+-spec(set_sender_in_attrs
       ([#xmlattr{}], jidlike() | undefined) -> [#xmlattr{}]).
 
 set_sender_in_attrs(Attrs, undefined) ->
@@ -193,7 +193,7 @@ set_sender_in_attrs(Attrs, Sender) ->
 %%     New_Stanza = exmpp_xml:xmlel()
 %% @doc Remove the sender.
 
--spec(remove_sender/1 :: (#xmlel{}) -> #xmlel{}).
+-spec(remove_sender (#xmlel{}) -> #xmlel{}).
 
 remove_sender(#xmlel{attrs = Attrs} = Stanza) ->
     New_Attrs = remove_sender_in_attrs(Attrs),
@@ -204,7 +204,7 @@ remove_sender(#xmlel{attrs = Attrs} = Stanza) ->
 %%     New_Attrs = [exmpp_xml:xmlnattribute()]
 %% @doc Remove the sender.
 
--spec(remove_sender_in_attrs/1 :: ([#xmlattr{}]) -> [#xmlattr{}]).
+-spec(remove_sender_in_attrs ([#xmlattr{}]) -> [#xmlattr{}]).
 
 remove_sender_in_attrs(Attrs) ->
     exmpp_xml:remove_attribute_from_list(Attrs, <<"from">>).
@@ -217,7 +217,7 @@ remove_sender_in_attrs(Attrs) ->
 %% The return value should be a JID and may be parsed with
 %% {@link exmpp_jid:parse/1}.
 
--spec(get_recipient/1 :: (#xmlel{}) -> binary() | undefined).
+-spec(get_recipient (#xmlel{}) -> binary() | undefined).
 
 get_recipient(#xmlel{attrs = Attrs} = _Stanza) ->
     get_recipient_from_attrs(Attrs).
@@ -230,7 +230,7 @@ get_recipient(#xmlel{attrs = Attrs} = _Stanza) ->
 %% The return value should be a JID and may be parsed with
 %% {@link exmpp_jid:parse/1}.
 
--spec(get_recipient_from_attrs/1 :: ([#xmlattr{}]) -> binary() | undefined).
+-spec(get_recipient_from_attrs ([#xmlattr{}]) -> binary() | undefined).
 
 get_recipient_from_attrs(Attrs) ->
     exmpp_xml:get_attribute_from_list_as_binary(Attrs, <<"to">>, undefined).
@@ -243,7 +243,7 @@ get_recipient_from_attrs(Attrs) ->
 %%
 %% If `Recipient' is set to `undefined', the recipient is removed.
 
--spec(set_recipient/2 ::
+-spec(set_recipient
       (#xmlel{}, jidlike() | undefined) -> #xmlel{}).
 
 set_recipient(#xmlel{attrs = Attrs} = Stanza, Recipient) ->
@@ -258,7 +258,7 @@ set_recipient(#xmlel{attrs = Attrs} = Stanza, Recipient) ->
 %%
 %% If `Recipient' is set to `undefined', the recipient is removed.
 
--spec(set_recipient_in_attrs/2 ::
+-spec(set_recipient_in_attrs
       ([#xmlattr{}], jidlike() | undefined) -> [#xmlattr{}]).
 
 set_recipient_in_attrs(Attrs, undefined) ->
@@ -273,7 +273,7 @@ set_recipient_in_attrs(Attrs, Recipient) ->
 %%     New_Stanza = exmpp_xml:xmlel()
 %% @doc Remove the recipient.
 
--spec(remove_recipient/1 :: (#xmlel{}) -> #xmlel{}).
+-spec(remove_recipient (#xmlel{}) -> #xmlel{}).
 
 remove_recipient(#xmlel{attrs= Attrs} = Stanza) ->
     New_Attrs = remove_recipient_in_attrs(Attrs),
@@ -284,7 +284,7 @@ remove_recipient(#xmlel{attrs= Attrs} = Stanza) ->
 %%     New_Attrs = [exmpp_xml:xmlnattribute()]
 %% @doc Remove the recipient.
 
--spec(remove_recipient_in_attrs/1 :: ([#xmlattr{}]) -> [#xmlattr{}]).
+-spec(remove_recipient_in_attrs ([#xmlattr{}]) -> [#xmlattr{}]).
 
 remove_recipient_in_attrs(Attrs) ->
     exmpp_xml:remove_attribute_from_list(Attrs, <<"to">>).
@@ -299,7 +299,7 @@ remove_recipient_in_attrs(Attrs) ->
 %% If `Sender' is set to `undefined', the sender is removed. If
 %% `Recipient' is set to `undefined', the recipient is removed.
 
--spec(set_jids/3 ::
+-spec(set_jids
       (#xmlel{}, jidlike(), jidlike()) -> #xmlel{}).
 
 set_jids(Stanza, From, To) ->
@@ -315,7 +315,7 @@ set_jids(Stanza, From, To) ->
 %% If `Sender' is set to `undefined', the sender is removed. If
 %% `Recipient' is set to `undefined', the recipient is removed.
 
--spec(set_jids_in_attrs/3 ::
+-spec(set_jids_in_attrs
       ([#xmlattr{}], jidlike(), jidlike()) -> [#xmlattr{}]).
 
 set_jids_in_attrs(Attrs, From, To) ->
@@ -326,7 +326,7 @@ set_jids_in_attrs(Attrs, From, To) ->
 %%     ID = binary()
 %% @doc Return the stanza ID.
 
--spec(get_id/1 :: (#xmlel{} | #iq{}) -> binary() | undefined).
+-spec(get_id (#xmlel{} | #iq{}) -> binary() | undefined).
 
 get_id(#xmlel{attrs = Attrs} = _Stanza) ->
     get_id_from_attrs(Attrs);
@@ -338,7 +338,7 @@ get_id(#iq{id = ID}) ->
 %%     ID = binary()
 %% @doc Return the stanza ID.
 
--spec(get_id_from_attrs/1 :: ([#xmlattr{}]) -> binary() | undefined).
+-spec(get_id_from_attrs ([#xmlattr{}]) -> binary() | undefined).
 
 get_id_from_attrs(Attrs) ->
     exmpp_xml:get_attribute_from_list_as_binary(Attrs, <<"id">>, undefined).
@@ -352,7 +352,7 @@ get_id_from_attrs(Attrs) ->
 %% If `ID' is `undefined' or empty, it's removed. If `ID' is `random', a
 %% random value is set.
 
--spec(set_id/2 :: (#xmlel{} | #iq{}, id()) -> #xmlel{} | #iq{}).
+-spec(set_id (#xmlel{} | #iq{}, id()) -> #xmlel{} | #iq{}).
 
 set_id(#xmlel{attrs = Attrs, name = Name} = Stanza, random) ->
     New_Attrs = set_id_in_attrs(Attrs, exmpp_utils:random_id(Name)),
@@ -375,7 +375,7 @@ set_id(#iq{} = Stanza, ID) ->
 %% If `ID' is `undefined' or empty, it's removed. If `ID' is `random', a
 %% random value is set.
 
--spec(set_id_in_attrs/2 :: ([#xmlattr{}], id()) -> [#xmlattr{}]).
+-spec(set_id_in_attrs ([#xmlattr{}], id()) -> [#xmlattr{}]).
 
 set_id_in_attrs(Attrs, ID) when ID == undefined; ID == <<>>; ID == "" ->
     exmpp_xml:remove_attribute_from_list(Attrs, <<"id">>);
@@ -389,7 +389,7 @@ set_id_in_attrs(Attrs, ID) ->
 %%     Type = binary()
 %% @doc Return the type of the stanza.
 
--spec(get_type/1 :: (#xmlel{} | #iq{}) -> binary() | undefined).
+-spec(get_type (#xmlel{} | #iq{}) -> binary() | undefined).
 
 get_type(#xmlel{attrs = Attrs} = _Stanza) ->
     get_type_from_attrs(Attrs);
@@ -411,7 +411,7 @@ type_to_binary(Type) when is_atom(Type) ->
 %%     Type = binary()
 %% @doc Return the type of the stanza.
 
--spec(get_type_from_attrs/1 :: ([#xmlattr{}]) -> binary() | undefined).
+-spec(get_type_from_attrs ([#xmlattr{}]) -> binary() | undefined).
 
 get_type_from_attrs(Attrs) ->
     exmpp_xml:get_attribute_from_list_as_binary(Attrs, <<"type">>, undefined).
@@ -422,7 +422,7 @@ get_type_from_attrs(Attrs) ->
 %%     New_Stanza = exmpp_xml:xmlel() | exmpp_iq:iq()
 %% @doc Set the type of the stanza.
 
--spec(set_type/2 :: (#xmlel{} | #iq{}, type()) -> #xmlel{} | #iq{}).
+-spec(set_type (#xmlel{} | #iq{}, type()) -> #xmlel{} | #iq{}).
 
 set_type(#xmlel{attrs = Attrs} = Stanza, Type) ->
     New_Attrs = set_type_in_attrs(Attrs, Type),
@@ -444,7 +444,7 @@ set_type(#iq{} = Stanza, Type) when is_list(Type) ->
 %%     New_Attrs = [exmpp_xml:xmlattr()]
 %% @doc Set the type of the stanza.
 
--spec(set_type_in_attrs/2 :: ([#xmlattr{}], type()) -> [#xmlattr{}]).
+-spec(set_type_in_attrs ([#xmlattr{}], type()) -> [#xmlattr{}]).
 
 set_type_in_attrs(Attrs, Type) when is_atom(Type) ->
     set_type_in_attrs(Attrs, type_to_binary(Type));
@@ -456,7 +456,7 @@ set_type_in_attrs(Attrs, Type) ->
 %%     Lang = binary()
 %% @doc Return the language of the stanza.
 
--spec(get_lang/1 :: (#xmlel{} | #iq{}) -> binary() | undefined).
+-spec(get_lang (#xmlel{} | #iq{}) -> binary() | undefined).
 
 get_lang(#xmlel{attrs = Attrs} = _Stanza) ->
     get_lang_from_attrs(Attrs);
@@ -468,7 +468,7 @@ get_lang(#iq{lang = Lang}) ->
 %%     Lang = binary()
 %% @doc Return the language of the stanza.
 
--spec(get_lang_from_attrs/1 :: ([#xmlattr{}]) -> binary() | undefined).
+-spec(get_lang_from_attrs ([#xmlattr{}]) -> binary() | undefined).
 
 get_lang_from_attrs(Attrs) ->
     exmpp_xml:get_attribute_from_list_as_binary(Attrs, ?NS_XML, <<"lang">>,
@@ -482,7 +482,7 @@ get_lang_from_attrs(Attrs) ->
 %%
 %% If `Lang' is `undefined' or empty, it's removed.
 
--spec(set_lang/2 :: (#xmlel{} | #iq{}, lang()) -> #xmlel{} | #iq{}).
+-spec(set_lang (#xmlel{} | #iq{}, lang()) -> #xmlel{} | #iq{}).
 
 set_lang(#xmlel{attrs = Attrs} = Stanza, Lang) ->
     New_Attrs = set_lang_in_attrs(Attrs, Lang),
@@ -498,7 +498,7 @@ set_lang(#iq{} = Stanza, Lang) ->
 %%
 %% If `Lang' is `undefined' or empty, it's removed.
 
--spec(set_lang_in_attrs/2 :: ([#xmlattr{}], lang()) -> [#xmlattr{}]).
+-spec(set_lang_in_attrs ([#xmlattr{}], lang()) -> [#xmlattr{}]).
 
 set_lang_in_attrs(Attrs, Lang)
   when Lang == undefined; Lang == <<>>; Lang == "" ->
@@ -517,7 +517,7 @@ set_lang_in_attrs(Attrs, Lang) ->
 %%
 %% @see reply_from_attrs/1.
 
--spec(reply/1 :: (#xmlel{}) -> #xmlel{}).
+-spec(reply (#xmlel{}) -> #xmlel{}).
 
 reply(#xmlel{attrs = Attrs} = Stanza) ->
     New_Attrs = reply_from_attrs(Attrs),
@@ -530,7 +530,7 @@ reply(#xmlel{attrs = Attrs} = Stanza) ->
 %%
 %% @see reply_from_attrs/1.
 
--spec(reply_without_content/1 :: (#xmlel{}) -> #xmlel{}).
+-spec(reply_without_content (#xmlel{}) -> #xmlel{}).
 
 reply_without_content(#xmlel{attrs = Attrs} = Stanza) ->
     New_Attrs = reply_from_attrs(Attrs),
@@ -541,7 +541,7 @@ reply_without_content(#xmlel{attrs = Attrs} = Stanza) ->
 %%     New_Attrs = [exmpp_xml:xmlattr()]
 %% @doc Handles `to' and `from' attributes to prepare a reply stanza.
 
--spec(reply_from_attrs/1 :: ([#xmlattr{}]) -> [#xmlattr{}]).
+-spec(reply_from_attrs ([#xmlattr{}]) -> [#xmlattr{}]).
 
 reply_from_attrs(Attrs) ->
     Sender = get_sender_from_attrs(Attrs),
@@ -557,7 +557,7 @@ reply_from_attrs(Attrs) ->
 %% If `Error' is an atom, it must be a standard condition defined by
 %% XMPP Core.
 
--spec(reply_with_error/2 :: (#xmlel{}, #xmlel{} | atom()) -> #xmlel{}).
+-spec(reply_with_error (#xmlel{}, #xmlel{} | atom()) -> #xmlel{}).
 
 reply_with_error(Stanza, Condition) when is_atom(Condition) ->
     Error = error(Stanza#xmlel.ns, Condition),
@@ -606,7 +606,7 @@ standard_conditions() ->
 %% `jabber:client' or `jabber:server'. This does not contain any text
 %% element.
 
--spec(error/2 :: (xmlname(), atom()) -> #xmlel{}).
+-spec(error (xmlname(), atom()) -> #xmlel{}).
 
 error(NS, Condition) ->
     error(NS, Condition, {undefined, undefined}).
@@ -624,7 +624,7 @@ error(NS, Condition) ->
 %% `jabber:client' or `jabber:server'. This does not contain any text
 %% element.
 
--spec(error/3 ::
+-spec(error
       (xmlname(), atom(), {lang(), binary() | string() | undefined}) -> #xmlel{}).
 
 error(NS, Condition, {Lang, Text}) ->
@@ -670,7 +670,7 @@ error(NS, Condition, Text) ->
 %% @see error/2.
 %% @see error/3.
 
--spec(stanza_error/2 :: (#xmlel{}, #xmlel{}) -> #xmlel{}).
+-spec(stanza_error (#xmlel{}, #xmlel{}) -> #xmlel{}).
 
 stanza_error(Stanza, Error) ->
     Stanza_Error = exmpp_xml:append_child(Stanza, Error),
@@ -686,7 +686,7 @@ stanza_error(Stanza, Error) ->
 %%
 %% @see stanza_error/2.
 
--spec(stanza_error_without_original/2 :: (#xmlel{}, #xmlel{}) -> #xmlel{}).
+-spec(stanza_error_without_original (#xmlel{}, #xmlel{}) -> #xmlel{}).
 
 stanza_error_without_original(Stanza, Error) ->
     Stanza_Error = exmpp_xml:set_children(Stanza, [Error]),
@@ -696,7 +696,7 @@ stanza_error_without_original(Stanza, Error) ->
 %%     Stanza = exmpp_xml:xmlel()
 %% @doc Tell if the stanza transports an error.
 
--spec(is_stanza_error/1 :: (#xmlel{}) -> bool()).
+-spec(is_stanza_error (#xmlel{}) -> bool()).
 
 is_stanza_error(Stanza) ->
     case get_type(Stanza) of
@@ -710,7 +710,7 @@ is_stanza_error(Stanza) ->
 %% @throws {stanza_error, error_type, no_error_element_found, Stanza}
 %% @doc Return the type of the error element.
 
--spec(get_error_type/1 :: (#xmlel{}) -> binary()).
+-spec(get_error_type (#xmlel{}) -> binary()).
 
 get_error_type(Stanza) ->
     case get_error(Stanza) of
@@ -730,7 +730,7 @@ get_error_type_from_error(Error) ->
 %% @throws {stanza_error, error_type, no_error_element_found, Stanza}
 %% @doc Set the type of the error element.
 
--spec(set_error_type/2 :: (#xmlel{}, binary()) -> #xmlel{}).
+-spec(set_error_type (#xmlel{}, binary()) -> #xmlel{}).
 
 set_error_type(Stanza, Type) ->
     case get_error(Stanza) of
@@ -754,7 +754,7 @@ set_error_type_in_error(Error, Type) ->
 %%
 %% If the condition is `undefined-condition', the type is unchanged.
 
--spec(set_error_type_from_condition/2 :: (#xmlel{}, atom()) -> #xmlel{}).
+-spec(set_error_type_from_condition (#xmlel{}, atom()) -> #xmlel{}).
 
 set_error_type_from_condition(Stanza, Condition) ->
     case get_error(Stanza) of
@@ -791,7 +791,7 @@ set_error_type_from_condition_in_error(Error, _Condition) ->
 %% If the namespace isn't neither `jabber:client' nor `jabber:server',
 %% the name of the first child is returned.
 
--spec(get_condition/1 :: (#xmlel{}) -> atom()).
+-spec(get_condition (#xmlel{}) -> atom()).
 
 get_condition(Stanza) ->
     case get_error(Stanza) of
@@ -827,7 +827,7 @@ get_condition_in_error(_Error) ->
 %%
 %% If there is no `<text/>' element, an empty string is returned.
 
--spec(get_text/1 :: (#xmlel{}) -> binary()).
+-spec(get_text (#xmlel{}) -> binary()).
 
 get_text(Stanza) ->
     case get_error(Stanza) of
@@ -865,7 +865,7 @@ get_text_in_error(Error) ->
 %% Server Dialback `jabber:server:dialback' are included as a prefixed
 %% namespace, with the `stream' prefix.
 
--spec(to_list/2 ::
+-spec(to_list
   (#xmlel{} | #iq{} | #xmlendtag{}, xmldefaultns()) -> string()).
 
 to_list(El, Default_NS) ->
@@ -883,7 +883,7 @@ to_list(El, Default_NS) ->
 %%
 %% To understand `Default_NS', see {@link exmpp_xml:xmlel_to_xmlelement/3}.
 
--spec(to_list/3 ::
+-spec(to_list
   (#xmlel{} | #iq{} | #xmlendtag{}, xmldefaultns(), xmlprefixednss()) -> string()).
 
 to_list(#iq{} = El, Default_NS, Prefixed_NS) ->
@@ -900,7 +900,7 @@ to_list(El, Default_NS, Prefixed_NS) ->
 %% `[?NS_JABBER_CLIENT, ?NS_JABBER_SERVER, ?NS_COMPONENT_ACCEPT,
 %% ?NS_COMPONENT_CONNECT]'.
 
--spec(to_list/1 :: (#xmlel{} | #iq{} | #xmlendtag{}) -> string()).
+-spec(to_list (#xmlel{} | #iq{} | #xmlendtag{}) -> string()).
 
 to_list(El) ->
     to_list(El, [
@@ -922,7 +922,7 @@ to_list(El) ->
 %% Server Dialback `jabber:server:dialback' are included as a prefixed
 %% namespace, with the `stream' prefix.
 
--spec(to_binary/2 ::
+-spec(to_binary
   (#xmlel{} | #iq{}| #xmlendtag{}, xmldefaultns()) -> binary()).
 
 to_binary(El, Default_NS) ->
@@ -940,7 +940,7 @@ to_binary(El, Default_NS) ->
 %%
 %% To understand `Default_NS', see {@link exmpp_xml:xmlel_to_xmlelement/3}.
 
--spec(to_binary/3 ::
+-spec(to_binary
   (#xmlel{} | #iq{}| #xmlendtag{}, xmldefaultns(), xmlprefixednss()) -> binary()).
 
 to_binary(#iq{} = El, Default_NS, Prefixed_NS) ->
@@ -957,7 +957,7 @@ to_binary(El, Default_NS, Prefixed_NS) ->
 %% `[?NS_JABBER_CLIENT, ?NS_JABBER_SERVER, ?NS_COMPONENT_ACCEPT,
 %% ?NS_COMPONENT_CONNECT]'.
 
--spec(to_binary/1 :: (#xmlel{} | #iq{}| #xmlendtag{}) -> binary()).
+-spec(to_binary (#xmlel{} | #iq{}| #xmlendtag{}) -> binary()).
 
 to_binary(El) ->
     to_binary(El, [
@@ -979,7 +979,7 @@ to_binary(El) ->
 %% Server Dialback `jabber:server:dialback' are included as a prefixed
 %% namespace, with the `stream' prefix.
 
--spec(to_iolist/2 ::
+-spec(to_iolist
   (#xmlel{} | #iq{}| #xmlendtag{}, xmldefaultns()) -> iolist()).
 
 to_iolist(El, Default_NS) ->
@@ -997,7 +997,7 @@ to_iolist(El, Default_NS) ->
 %%
 %% To understand `Default_NS', see {@link exmpp_xml:xmlel_to_xmlelement/3}.
 
--spec(to_iolist/3 ::
+-spec(to_iolist
   (#xmlel{} | #iq{}| #xmlendtag{}, xmldefaultns(), xmlprefixednss()) -> iolist()).
 
 to_iolist(#iq{} = El, Default_NS, Prefixed_NS) ->
@@ -1014,7 +1014,7 @@ to_iolist(El, Default_NS, Prefixed_NS) ->
 %% `[?NS_JABBER_CLIENT, ?NS_JABBER_SERVER, ?NS_COMPONENT_ACCEPT,
 %% ?NS_COMPONENT_CONNECT]'.
 
--spec(to_iolist/1 :: (#xmlel{} | #iq{}| #xmlendtag{}) -> iolist()).
+-spec(to_iolist (#xmlel{} | #iq{}| #xmlendtag{}) -> iolist()).
 
 to_iolist(El) ->
     to_iolist(El, [

--- a/src/core/exmpp_utils.erl
+++ b/src/core/exmpp_utils.erl
@@ -46,8 +46,7 @@
 %% {@link erlang:integer_to_list/1} is used. For a binary, {@link
 %% erlang:binary_to_list/1} is used. A string is returned as is.
 
--spec(any_to_list/1 ::
-      (binary() | string() | integer() | atom()) -> string()).
+-spec(any_to_list(binary() | string() | integer() | atom()) -> string()).
 
 any_to_list(Atom) when is_atom(Atom) ->
     atom_to_list(Atom);
@@ -68,8 +67,7 @@ any_to_list(Binary) when is_binary(Binary) ->
 %% {@link erlang:integer_to_list/1} is used. For a string, {@link
 %% erlang:list_to_binary/1} is used. A binary is returned as is.
 
--spec(any_to_binary/1 ::
-      (binary() | string() | integer() | atom()) -> binary()).
+-spec(any_to_binary(binary() | string() | integer() | atom()) -> binary()).
 
 any_to_binary(Atom) when is_atom(Atom) ->
     any_to_binary(atom_to_list(Atom));
@@ -88,8 +86,7 @@ any_to_binary(Binary) when is_binary(Binary) ->
 %%
 %% @see strip/3.
 
--spec(strip/1 ::
-      (binary()) -> binary();
+-spec(strip(binary()) -> binary();
       (string()) -> string()
 		       ).
 
@@ -109,8 +106,7 @@ strip(Stream) ->
 %%
 %% @see strip/3.
 
--spec(strip/2 ::
-      (binary(), left | right | both) -> binary();
+-spec(strip(binary(), left | right | both) -> binary();
       (string(), left | right | both) -> string()
 					    ).
 
@@ -160,7 +156,7 @@ strip_right([]) ->
 %%
 %% @see random_id/1.
 
--spec(random_id/0 :: () -> string()).
+-spec(random_id() -> string()).
 
 random_id() ->
     random_id("exmpp").
@@ -175,7 +171,7 @@ random_id() ->
 %%
 %% The ID is not guaranted to be unique.
 
--spec(random_id/1 :: (string() | undefined) -> string()).
+-spec(random_id(string() | undefined) -> string()).
 
 random_id(undefined) ->
     integer_to_list(random:uniform(65536 * 65536));

--- a/src/core/exmpp_xml.erl
+++ b/src/core/exmpp_xml.erl
@@ -467,7 +467,7 @@ load_builtin_known_lists() ->
 %%     Driver = atom()
 %% @doc Add a new XML engine.
 
--spec(register_engine/2 :: (atom(), atom()) -> ok).
+-spec(register_engine (atom(), atom()) -> ok).
 
 register_engine(Name, Driver) ->
     register_engine(Name, undefined, Driver).
@@ -478,7 +478,7 @@ register_engine(Name, Driver) ->
 %%     Driver = atom()
 %% @doc Add a new XML engine.
 
--spec(register_engine/3 :: (atom(), string() | undefined, atom()) -> ok).
+-spec(register_engine (atom(), string() | undefined, atom()) -> ok).
 
 register_engine(Name, Driver_Path, Driver)
   when is_atom(Name) ->
@@ -496,7 +496,7 @@ register_engine(Name, Driver_Path, Driver)
 %%     Engine_Name = atom()
 %% @doc Return the list of XML engines.
 
--spec(get_engine_names/0 :: () -> [atom()]).
+-spec(get_engine_names () -> [atom()]).
 
 get_engine_names() ->
     ets:safe_fixtable(?ENGINES_REGISTRY, true),
@@ -514,7 +514,7 @@ get_engine_names2(Prev_Key, Keys) ->
 %%     Engine_Name = atom()
 %% @doc Tell if `Engine_Name' is available.
 
--spec(is_engine_available/1 :: (atom()) -> bool()).
+-spec(is_engine_available (atom()) -> bool()).
 
 is_engine_available(Engine_Name) ->
     ets:member(?ENGINES_REGISTRY, Engine_Name).
@@ -524,7 +524,7 @@ is_engine_available(Engine_Name) ->
 %%     Driver_Name = atom() | undefined
 %% @doc Return the port driver name associated to the given engine.
 
--spec(get_engine_driver/1 :: (atom()) -> atom() | undefined).
+-spec(get_engine_driver (atom()) -> atom() | undefined).
 
 get_engine_driver(Engine_Name) ->
     case ets:match(?ENGINES_REGISTRY,
@@ -548,7 +548,7 @@ get_engine_driver(Engine_Name) ->
 %% If `check_nss' is enabled, all occurences of these namespaces will be
 %% represented as an atom().
 
--spec(add_known_nss/2 :: (atom(), [atom()]) -> ok).
+-spec(add_known_nss (atom(), [atom()]) -> ok).
 
 add_known_nss(List_Name, List) ->
     case gen_server:call(?SERVER, {add_known, nss, List_Name, List}) of
@@ -565,7 +565,7 @@ add_known_nss(List_Name, List) ->
 %% If `check_elems' is enabled, all occurences of these names will be
 %% represented as an atom().
 
--spec(add_known_elems/2 :: (atom(), [atom()]) -> ok).
+-spec(add_known_elems (atom(), [atom()]) -> ok).
 
 add_known_elems(List_Name, List) ->
     case gen_server:call(?SERVER, {add_known, names, List_Name, List}) of
@@ -595,7 +595,7 @@ add_known_elems(List_Name, List) ->
 %% @see start_parser/1.
 %% @see xmlparseroption().
 
--spec(start_parser/0 :: () -> xmlparser()).
+-spec(start_parser () -> xmlparser()).
 
 start_parser() ->
     start_parser([]).
@@ -618,7 +618,7 @@ start_parser() ->
 %%     xml:stop_parser(Parser).
 %% '''
 
--spec(start_parser/1 :: ([xmlparseroption()]) -> xmlparser()).
+-spec(start_parser ([xmlparseroption()]) -> xmlparser()).
 
 start_parser(Options) ->
     %% Start a port driver instance.
@@ -641,7 +641,7 @@ start_parser(Options) ->
 %%     Parser = xmlparser()
 %% @doc Reset the parser with the same previous options.
 
--spec(reset_parser/1 :: (xmlparser()) -> xmlparser()).
+-spec(reset_parser (xmlparser()) -> xmlparser()).
 
 reset_parser(Parser) ->
     reset_parser(Parser, []).
@@ -651,7 +651,7 @@ reset_parser(Parser) ->
 %%     Options = [xmlparseroption()]
 %% @doc Reset the parser and update its options.
 
--spec(reset_parser/2 :: (xmlparser(), [xmlparseroption()]) -> xmlparser()).
+-spec(reset_parser (xmlparser(), [xmlparseroption()]) -> xmlparser()).
 
 reset_parser(#xml_parser{port = Port} = Parser, Options) ->
     New_Options = merge_options(Parser#xml_parser.options, Options),
@@ -675,7 +675,7 @@ reset_parser2(Parser, Options) ->
 %%
 %% @see start_parser/0. `start_parser/0' for an example
 
--spec(stop_parser/1 :: (xmlparser()) -> ok).
+-spec(stop_parser (xmlparser()) -> ok).
 
 stop_parser(#xml_parser{port = Port} = _Parser) ->
     unlink(Port),
@@ -703,7 +703,7 @@ stop_parser(#xml_parser{port = Port} = _Parser) ->
 %%     xml:parser_final(Parser, "").
 %% '''
 
--spec(parse/2 ::
+-spec(parse
       (xmlparser(), binary() | string()) -> [xmlnode() | xmlendtag()] | continue).
 
 parse(Parser, Data) when is_list(Data) ->
@@ -726,7 +726,7 @@ parse(#xml_parser{port = Port} = _Parser, Data) when is_binary(Data) ->
 %%
 %% @see parse/2. `parse/2' for an example
 
--spec(parse_final/2 ::
+-spec(parse_final
       (xmlparser(), binary() | string()) -> [xmlnode() | xmlendtag()] | done).
 
 parse_final(Parser, Data) when is_list(Data) ->
@@ -744,7 +744,7 @@ parse_final(#xml_parser{port = Port} = _Parser, Data) when is_binary(Data) ->
 %% this function will take care of it. It'll use default options; see
 %% {@link start_parser/1} for any related informations.
 
--spec(parse_document/1 ::
+-spec(parse_document
       (binary() | string()) -> [xmlnode() | xmlendtag()] | done).
 
 parse_document(Document) ->
@@ -762,7 +762,7 @@ parse_document(Document) ->
 %%
 %% Return values are the same as {@link parse_final/2}.
 
--spec(parse_document/2 ::
+-spec(parse_document
       (binary() | string(), [xmlparseroption()]) ->
 	     [xmlnode() | xmlendtag()] | done).
 
@@ -793,7 +793,7 @@ parse_document(Document, Parser_Options) ->
 %% will set `{root_depth, none}' (which can be overriden); see {@link
 %% start_parser/1} for any related informations.
 
--spec(parse_document_fragment/1 ::
+-spec(parse_document_fragment
       (binary() | string()) -> [xmlnode() | xmlendtag()] | continue).
 
 parse_document_fragment(Fragment) ->
@@ -818,7 +818,7 @@ parse_document_fragment(Fragment) ->
 %%
 %% Return values are the same as {@link parse_final/2}.
 
--spec(parse_document_fragment/2 ::
+-spec(parse_document_fragment
       (binary() | string(), [xmlparseroption()]) ->
 	     [xmlnode() | xmlendtag()] | continue).
 
@@ -850,7 +850,7 @@ port_revision(#xml_parser{port = Port} = _Parser) ->
 %% @todo Like for elements and attributes, implement a more flexible
 %% matching (`string()' vs. `atom()').
 
--spec(is_ns_declared_here/2 :: (xmlel(), xmlname()) -> bool()).
+-spec(is_ns_declared_here (xmlel(), xmlname()) -> bool()).
 
 is_ns_declared_here(#xmlel{declared_ns = Declared_NS}, NS) ->
     lists:keymember(NS, 1, Declared_NS).
@@ -865,7 +865,7 @@ is_ns_declared_here(#xmlel{declared_ns = Declared_NS}, NS) ->
 %% @todo Like for elements and attributes, implement a more flexible
 %% matching (`string()' vs. `atom()').
 
--spec(declare_ns_here/3 :: (xmlel(), xmlname(), string() | none) -> xmlel()).
+-spec(declare_ns_here (xmlel(), xmlname(), string() | none) -> xmlel()).
 
 declare_ns_here(#xmlel{declared_ns = Declared_NS} = XML_Element,
 		NS, Prefix) ->
@@ -879,7 +879,7 @@ declare_ns_here(#xmlel{declared_ns = Declared_NS} = XML_Element,
 %% @doc Return the namespace as a string, regardless of the original
 %% encoding.
 
--spec(get_ns_as_list/1 :: (xmlel()) -> string() | undefined).
+-spec(get_ns_as_list (xmlel()) -> string() | undefined).
 
 get_ns_as_list(#xmlel{ns = undefined}) ->
     undefined;
@@ -895,7 +895,7 @@ as_list(V) when is_list(V) -> V.
 %% @doc Return the namespace as an atom, regardless of the original
 %% encoding.
 
--spec(get_ns_as_atom/1 :: (xmlel()) -> atom() | undefined).
+-spec(get_ns_as_atom (xmlel()) -> atom() | undefined).
 
 get_ns_as_atom(#xmlel{ns = undefined}) ->
     undefined;
@@ -921,7 +921,7 @@ as_atom(V) when is_list(V) -> list_to_atom(V).
 %% Attr = #xmlattr{name = Name, value = Value}.
 %% '''
 
--spec(attribute/2 ::
+-spec(attribute
       (attributename(), binary() | string() | atom() | integer()) ->
 	     xmlattr()).
 
@@ -945,7 +945,7 @@ set_attr_value({Name, _}, Value) ->
 %% Attr = #xmlattr{ns = NS, name = Name, value = Value}.
 %% '''
 
--spec(attribute/3 ::
+-spec(attribute
       (xmlname(), attributename(), binary() | string() | atom() | integer()) ->
 	     xmlattr()).
 
@@ -959,7 +959,7 @@ attribute(NS, Name, Value) when is_binary(Name) ->
 %%
 %% It takes care of comparison between string and atom.
 
--spec(attribute_matches/2 :: (xmlattr_any(), xmlname() | attributename()) -> bool()).
+-spec(attribute_matches (xmlattr_any(), xmlname() | attributename()) -> bool()).
 
 attribute_matches(#xmlattr{name = Name}, Name) ->
     true;
@@ -984,7 +984,7 @@ attribute_matches(_Attr, _Name) ->
 %%
 %% It takes care of comparison between string and atom.
 
--spec(attribute_matches/3 ::
+-spec(attribute_matches
       (xmlattr(), xmlname(), xmlname() | attributename()) -> bool()).
 
 attribute_matches(Attr, NS, Name) when is_list(Name) ->
@@ -1014,12 +1014,12 @@ attribute_matches(_Attr, _NS, _Name) ->
 %% both clauses take a list() as a first argument. So until it can look
 %% inside those list(), we specify a less strict contract.
 %%
-%% -spec(get_attribute_node_from_list/2 ::
+%% -spec(get_attribute_node_from_list
 %%   ([], xmlname())              -> undefined;
 %%   ([xmlattr()], xmlname())     -> xmlattr() | undefined;
 %%   ([xmlattr_old()], xmlname()) -> xmlattr_old() | undefined).
 
--spec(get_attribute_node_from_list/2 ::
+-spec(get_attribute_node_from_list
       ([xmlattr() | xmlattr_old()], attributename()) ->
 	     xmlattr() | xmlattr_old() | undefined).
 
@@ -1041,7 +1041,7 @@ get_attribute_node_from_list([], _Name) ->
 %%
 %% Return `undefined' if the attribute isn't found.
 
--spec(get_attribute_node_from_list/3 ::
+-spec(get_attribute_node_from_list
       ([xmlattr()], xmlname(), attributename()) -> xmlattr() | undefined).
 
 get_attribute_node_from_list([Attr | Rest], NS, Name) ->
@@ -1060,7 +1060,7 @@ get_attribute_node_from_list([], _NS, _Name) ->
 %%
 %% Return `undefined' if the attribute isn't found.
 
--spec(get_attribute_node/2 ::
+-spec(get_attribute_node
       (xmlel(), attributename())     -> xmlattr() | undefined;
       (xmlel_old(), attributename()) -> xmlattr_old() | undefined;
       (undefined, attributename())   -> undefined).
@@ -1081,7 +1081,7 @@ get_attribute_node(undefined, _Name) ->
 %%
 %% Return `undefined' if the attribute isn't found.
 
--spec(get_attribute_node/3 ::
+-spec(get_attribute_node
       (xmlel(), xmlname(), attributename())   -> xmlattr() | undefined;
       (undefined, xmlname(), attributename()) -> undefined).
 
@@ -1109,12 +1109,12 @@ get_attribute_node(undefined, _NS, _Name) ->
 %% both clauses take a list() as a first argument. So until it can look
 %% inside those list(), we specify a less strict contract.
 %%
-%% -spec(get_attribute_from_list/3 ::
+%% -spec(get_attribute_from_list
 %%   ([], attributename(), Default)              -> Default;
 %%   ([xmlattr()], attributename(), Default)     -> binary() | Default;
 %%   ([xmlattr_old()], attributename(), Default) -> string() | Default).
 
--spec(get_attribute_from_list/3 ::
+-spec(get_attribute_from_list
       ([xmlattr() | xmlattr_old()], attributename(), Default) ->
 	     binary() | string() | Default).
 
@@ -1139,7 +1139,7 @@ get_attribute_from_list(Attrs, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_from_list/4 ::
+-spec(get_attribute_from_list
       ([xmlattr()], xmlname(), attributename(), Default) -> binary() | Default).
 
 get_attribute_from_list(Attrs, NS, Attr_Name, Default) ->
@@ -1165,7 +1165,7 @@ get_attribute_from_list(Attrs, NS, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute/3 ::
+-spec(get_attribute
       (xmlel(), attributename(), Default)     -> binary() | Default;
       (xmlel_old(), attributename(), Default) -> string() | Default;
       (undefined, attributename(), Default)   -> Default).
@@ -1188,7 +1188,7 @@ get_attribute(undefined, _Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute/4 ::
+-spec(get_attribute
       (xmlel(), xmlname(), attributename(), Default)   -> binary() | Default;
       (undefined, xmlname(), attributename(), Default) -> Default).
 
@@ -1207,7 +1207,7 @@ get_attribute(undefined, _NS, _Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_from_list_as_list/3 ::
+-spec(get_attribute_from_list_as_list
       ([xmlattr()] | [xmlattr_old()], attributename(), Default) -> string() | Default).
 
 get_attribute_from_list_as_list(Attrs, Attr_Name, Default) ->
@@ -1231,7 +1231,7 @@ get_attribute_from_list_as_list(Attrs, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_from_list_as_list/4 ::
+-spec(get_attribute_from_list_as_list
       ([xmlattr()], xmlname(), attributename(), Default) -> string() | Default).
 
 get_attribute_from_list_as_list(Attrs, NS, Attr_Name, Default) ->
@@ -1252,7 +1252,7 @@ get_attribute_from_list_as_list(Attrs, NS, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_as_list/3 ::
+-spec(get_attribute_as_list
       (xmlel_any(), attributename(), Default) -> string() | Default;
       (undefined, attributename(), Default)   -> Default).
 
@@ -1276,7 +1276,7 @@ get_attribute_as_list(undefined, _Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_as_list/4 ::
+-spec(get_attribute_as_list
       (xmlel() | undefined, xmlname(), attributename(), Default) -> string() | Default).
 
 get_attribute_as_list(#xmlel{attrs = Attrs} = _XML_Element, NS, Name,
@@ -1295,7 +1295,7 @@ get_attribute_as_list(undefined, _NS, _Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_from_list_as_binary/3 ::
+-spec(get_attribute_from_list_as_binary
       ([xmlattr()] | [xmlattr_old()], attributename(), Default) -> binary() | Default).
 
 get_attribute_from_list_as_binary(Attrs, Attr_Name, Default) ->
@@ -1319,7 +1319,7 @@ get_attribute_from_list_as_binary(Attrs, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_from_list_as_binary/4 ::
+-spec(get_attribute_from_list_as_binary
       ([xmlattr()], xmlname(), attributename(), Default) -> binary() | Default).
 
 get_attribute_from_list_as_binary(Attrs, NS, Attr_Name, Default) ->
@@ -1340,7 +1340,7 @@ get_attribute_from_list_as_binary(Attrs, NS, Attr_Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_as_binary/3 ::
+-spec(get_attribute_as_binary
       (xmlel_any(), attributename(), Default) -> binary() | Default;
       (undefined, attributename(), Default)   -> Default).
 
@@ -1364,7 +1364,7 @@ get_attribute_as_binary(undefined, _Name, Default) ->
 %%
 %% Return `Default' if the attribute isn't found.
 
--spec(get_attribute_as_binary/4 ::
+-spec(get_attribute_as_binary
       (xmlel(), xmlname(), attributename(), Default)   -> binary() | Default;
       (undefined, xmlname(), attributename(), Default) -> Default).
 
@@ -1379,7 +1379,7 @@ get_attribute_as_binary(undefined, _NS, _Name, Default) ->
 %%     Attr_Name = binary()
 %% @doc Check the presence for attribute `Attr_Name' in the list.
 
--spec(has_attribute_in_list/2 ::
+-spec(has_attribute_in_list
       ([xmlattr()] | [xmlattr_old()], attributename()) -> bool()).
 
 has_attribute_in_list(Attrs, Name) ->
@@ -1395,7 +1395,7 @@ has_attribute_in_list(Attrs, Name) ->
 %% @doc Check the presence for attribute `Attr_Name' with namespace `NS'
 %% in the list.
 
--spec(has_attribute_in_list/3 ::
+-spec(has_attribute_in_list
       ([xmlattr()], xmlname(), attributename()) -> bool()).
 
 has_attribute_in_list(Attrs, NS, Name) ->
@@ -1409,7 +1409,7 @@ has_attribute_in_list(Attrs, NS, Name) ->
 %%     Attr_Name = binary()
 %% @doc Check the presence for attribute `Attr_Name' in the XML element.
 
--spec(has_attribute/2 ::
+-spec(has_attribute
       (xmlel_any() | undefined, attributename()) -> bool()).
 
 has_attribute(#xmlel{attrs = Attrs} = _XML_Element, Name) ->
@@ -1426,7 +1426,7 @@ has_attribute(undefined, _Name) ->
 %% @doc Check the presence for attribute `Attr_Name' with namespace `NS'
 %% in the XML element.
 
--spec(has_attribute/3 ::
+-spec(has_attribute
       (xmlel_any() | undefined, xmlname(), attributename()) -> bool()).
 
 has_attribute(#xmlel{attrs = Attrs} = _XML_Element, NS, Name) ->
@@ -1450,13 +1450,13 @@ has_attribute(undefined, _NS, _Name) ->
 %% both clauses take a list() as a first argument. So until it can look
 %% inside those list(), we specify a less strict contract.
 %%
-%% -spec(set_attribute_in_list/2 ::
+%% -spec(set_attribute_in_list
 %%   ([], xmlattr()                   -> [xmlattr()];
 %%   ([], xmlattr_old())              -> [xmlattr_old()];
 %%   ([xmlattr()], xmlattr()          -> [xmlattr()];
 %%   ([xmlattr_old()], xmlattr_old()) -> [xmlattr_old()]).
 
--spec(set_attribute_in_list/2 ::
+-spec(set_attribute_in_list
       ([xmlattr() | xmlattr_old()], xmlattr() | xmlattr_old()) ->
 	     [xmlattr() | xmlattr_old()]).
 
@@ -1500,13 +1500,13 @@ set_attribute_in_list2([], New_Attr, New_Attrs) ->
 %% both clauses take a list() as a first argument. So until it can look
 %% inside those list(), we specify a less strict contract.
 %%
-%% -spec(set_attribute_in_list/3 ::
+%% -spec(set_attribute_in_list
 %%   ([xmlattr()], attributename(), binary() | string() | atom() | integer()) ->
 %%       [xmlattr()];
 %%   ([xmlattr_old()], attributename(), binary() | string() | atom() | integer()) ->
 %%       [xmlattr_old()]).
 
--spec(set_attribute_in_list/3 ::
+-spec(set_attribute_in_list
       ([xmlattr() | xmlattr_old()],
        attributename(), binary() | string() | atom() | integer()) ->
 	     [xmlattr() | xmlattr_old()]).
@@ -1546,7 +1546,7 @@ set_attribute_in_list2([], Name, Value, New_Attrs) ->
 %% If the attribute is to be added, this function use the {@link
 %% xmlattr()} record.
 
--spec(set_attribute_in_list/4 ::
+-spec(set_attribute_in_list
       ([xmlattr()], xmlname(), attributename(),
        binary() | string() | atom() | integer()) ->
 	     [xmlattr()]).
@@ -1575,7 +1575,7 @@ set_attribute_in_list2([], NS, Name, Value, New_Attrs) ->
 %% If a match is found, `Attr' will replace the old attribute as is,
 %% regardless of the format of the latter.
 
--spec(set_attribute/2 ::
+-spec(set_attribute
       (xmlel(), xmlattr() | xmlattr_old())     -> xmlel();
       (xmlel_old(), xmlattr() | xmlattr_old()) -> xmlel_old()).
 
@@ -1593,7 +1593,7 @@ set_attribute(#xmlelement{attrs = Attrs} = XML_Element, Attr) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Add a new attribute or change the value of an existing attribute.
 
--spec(set_attribute/3 ::
+-spec(set_attribute
       (xmlel(), attributename(), binary() | string() | atom() | integer()) ->
 	     xmlel();
       (xmlel_old(), attributename(), binary() | string() | atom() | integer()) ->
@@ -1637,7 +1637,7 @@ set_attribute2([], Name, Value, New_Attrs) ->
 %% @doc Add a new attribute or change the value of an existing attribute
 %% with the same name and the `NS' namespace URI.
 
--spec(set_attribute/4 ::
+-spec(set_attribute
       (xmlel(), xmlname(), attributename(), binary() | string() | atom() | integer()) ->
 	     xmlel()).
 
@@ -1668,7 +1668,7 @@ set_attribute_ns2([], NS, Name, Value, New_Attrs) ->
 %% Existing attributes are not completly overwritten by the ones present
 %% in `Attrs_Spec'. They are simply updated.
 
--spec(set_attributes/2 ::
+-spec(set_attributes
       (xmlel(),
        [xmlattr() |
 	{attributename(), binary() | string() | atom() | integer()} |
@@ -1707,12 +1707,12 @@ set_attributes(XML_Element, []) ->
 %% both clauses take a list() as a first argument. So until it can look
 %% inside those list(), we specify a less strict contract.
 %%
-%% -spec(remove_attribute_from_list/2 ::
+%% -spec(remove_attribute_from_list
 %%   ([], attributename())              -> [];
 %%   ([xmlattr()], attributename())     -> [xmlattr()];
 %%   ([xmlattr_old()], attributename()) -> [xmlattr_old()]).
 
--spec(remove_attribute_from_list/2 ::
+-spec(remove_attribute_from_list
       ([xmlattr() | xmlattr_old()], attributename()) -> [xmlattr() | xmlattr_old()]).
 
 remove_attribute_from_list(Attrs, Name)  when is_binary(Name) ->
@@ -1741,7 +1741,7 @@ remove_attribute_from_list2([], _Name, New_Attrs) ->
 %% If `Attr_Name' doesn't exist, this function has no effect (it won't
 %% return an error).
 
--spec(remove_attribute_from_list/3 ::
+-spec(remove_attribute_from_list
       ([xmlattr()], xmlname(), attributename()) -> [xmlattr()]).
 
 remove_attribute_from_list(Attrs, NS, Name) when is_binary(Name) ->
@@ -1767,7 +1767,7 @@ remove_attribute_from_list2([], _NS, _Name, New_Attrs) ->
 %% If `Attr_Name' doesn't exist, this function has no effect (it won't
 %% return an error).
 
--spec(remove_attribute/2 ::
+-spec(remove_attribute
       (xmlel(), attributename())     -> xmlel();
       (xmlel_old(), attributename()) -> xmlel_old()).
 
@@ -1790,7 +1790,7 @@ remove_attribute(#xmlelement{attrs = Attrs} = XML_Element, Name) ->
 %% If `Attr_Name' doesn't exist, this function has no effect (it won't
 %% return an error).
 
--spec(remove_attribute/3 ::
+-spec(remove_attribute
       (xmlel(), xmlname(), attributename()) -> xmlel()).
 
 remove_attribute(#xmlel{attrs = Attrs} = XML_Element, NS, Name) when is_binary(Name) ->
@@ -1815,7 +1815,7 @@ remove_attribute(#xmlel{attrs = Attrs} = XML_Element, NS, Name) when is_binary(N
 %% XML_Element = #xmlel{name = Name}.
 %% '''
 
--spec(element/1 :: (xmlname()) -> xmlel()).
+-spec(element (xmlname()) -> xmlel()).
 
 element(Name) ->
     #xmlel{name = Name}.
@@ -1831,7 +1831,7 @@ element(Name) ->
 %% XML_Element = #xmlel{ns = NS, name = Name}.
 %% '''
 
--spec(element/2 :: (xmlname(), xmlname()) -> xmlel()).
+-spec(element (xmlname(), xmlname()) -> xmlel()).
 
 element(NS, Name) ->
     #xmlel{ns = NS, name = Name}.
@@ -1849,7 +1849,7 @@ element(NS, Name) ->
 %% XML_Element = #xmlel{ns = NS, name = Name}.
 %% '''
 
--spec(element/4 ::
+-spec(element
       (xmlname(), xmlname(), [xmlattr()], [xmlel() | xmlcdata()]) -> xmlel()).
 
 element(NS, Name, Attrs, Children) ->
@@ -1861,7 +1861,7 @@ element(NS, Name, Attrs, Children) ->
 %% @doc Return the name of an element as list, regardless of the
 %% original encoding.
 
--spec(get_name_as_list/1 :: (xmlel_any()) -> string()).
+-spec(get_name_as_list (xmlel_any()) -> string()).
 
 get_name_as_list(#xmlel{name = Name}) ->
     as_list(Name);
@@ -1874,7 +1874,7 @@ get_name_as_list(#xmlelement{name = Name}) ->
 %% @doc Return the name of an element as atom, regardless of the
 %% original encoding.
 
--spec(get_name_as_atom/1 :: (xmlel_any()) -> atom()).
+-spec(get_name_as_atom (xmlel_any()) -> atom()).
 
 get_name_as_atom(#xmlel{name = Name}) ->
     as_atom(Name);
@@ -1888,7 +1888,7 @@ get_name_as_atom(#xmlelement{name = Name}) ->
 %%
 %% It takes care of comparison between string and atom.
 
--spec(element_matches/2 :: (xmlel_any(), xmlname()) -> bool()).
+-spec(element_matches (xmlel_any(), xmlname()) -> bool()).
 
 element_matches(#xmlel{name = Name}, Name) ->
     true;
@@ -1920,7 +1920,7 @@ element_matches(_XML_Element, _Name) ->
 %%
 %% It takes care of comparison between string and atom.
 
--spec(element_matches/3 :: (xmlel(), xmlname(), xmlname()) -> bool()).
+-spec(element_matches (xmlel(), xmlname(), xmlname()) -> bool()).
 
 element_matches(#xmlel{ns = NS, name = Name}, NS, Name) ->
     true;
@@ -1956,7 +1956,7 @@ element_matches(_XML_Element, _NS, _Name) ->
 %%
 %% It takes care of comparison between string and atom.
 
--spec(element_matches_by_ns/2 :: (xmlel(), xmlname()) -> bool()).
+-spec(element_matches_by_ns (xmlel(), xmlname()) -> bool()).
 
 element_matches_by_ns(#xmlel{ns = NS}, NS) ->
     true;
@@ -1980,7 +1980,7 @@ element_matches_by_ns(_XML_Element, _NS) ->
 %% If no element with the given name is found, it returns `undefined'.
 %% This will only search among direct children.
 
--spec(get_element/2 ::
+-spec(get_element
       (xmlel_any() | undefined, xmlname()) -> xmlel_any() | undefined).
 
 get_element(#xmlel{children = Children}, Name) ->
@@ -2011,7 +2011,7 @@ get_element2(undefined, _Name) ->
 %% If no element with the given name is found, it returns `undefined'.
 %% This will only search among direct children.
 
--spec(get_element/3 ::
+-spec(get_element
       (xmlel() | undefined, xmlname(), xmlname()) -> xmlel() | undefined).
 
 get_element(#xmlel{children = Children}, NS, Name) ->
@@ -2038,7 +2038,7 @@ get_element2(undefined, _NS, _Name) ->
 %%
 %% This will only search among direct children.
 
--spec(get_elements/2 ::
+-spec(get_elements
       (xmlel_any() | undefined, xmlname()) -> [xmlel_any()]).
 
 get_elements(#xmlel{children = Children}, Name) ->
@@ -2070,7 +2070,7 @@ filter_by_name(Searched_Name) ->
 %%
 %% This will only search among direct children.
 
--spec(get_elements/3 ::
+-spec(get_elements
       (xmlel() | undefined, xmlname(), xmlname()) -> [xmlel()]).
 
 get_elements(#xmlel{children = Children}, NS, Name) ->
@@ -2102,7 +2102,7 @@ filter_by_name(Searched_NS, Searched_Name) ->
 %%
 %% This function is particularly usefull to extract XMPP error codes.
 
--spec(get_element_by_ns/2 ::
+-spec(get_element_by_ns
       (xmlel() | undefined, xmlname()) -> xmlel() | undefined).
 
 get_element_by_ns(#xmlel{children = Children}, NS) ->
@@ -2125,7 +2125,7 @@ get_element_by_ns2(undefined, _NS) ->
 %%     Name = atom() | string()
 %% @doc Check the presence for element `Name' in the children.
 
--spec(has_element/2 ::
+-spec(has_element
       (xmlel_any() | undefined, xmlname()) -> bool()).
 
 has_element(XML_Element, Name) ->
@@ -2141,7 +2141,7 @@ has_element(XML_Element, Name) ->
 %% @doc Check the presence for element `Name' with `NS' namespace URI in
 %% the children.
 
--spec(has_element/3 ::
+-spec(has_element
       (xmlel() | undefined, xmlname(), xmlname()) -> bool()).
 
 has_element(XML_Element, NS, Name) ->
@@ -2156,7 +2156,7 @@ has_element(XML_Element, NS, Name) ->
 %% @doc Check the presence for any elements with `NS' namespace URI in
 %% the children.
 
--spec(has_element_by_ns/2 ::
+-spec(has_element_by_ns
       (xmlel() | undefined, xmlname()) -> bool()).
 
 has_element_by_ns(XML_Element, NS) ->
@@ -2171,7 +2171,7 @@ has_element_by_ns(XML_Element, NS) ->
 %% @doc Get all the element children of the given element, skipping
 %% non-element nodes likes cdata.
 
--spec(get_child_elements/1 :: (xmlel_any() | undefined) -> [xmlel_any()]).
+-spec(get_child_elements (xmlel_any() | undefined) -> [xmlel_any()]).
 
 get_child_elements(#xmlel{children = Children}) ->
     get_child_elements2(Children);
@@ -2197,7 +2197,7 @@ is_element(_)             -> false.
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Remove the first child with the name `Name'.
 
--spec(remove_element/2 :: (xmlel_any(), xmlname()) -> xmlel_any()).
+-spec(remove_element (xmlel_any(), xmlname()) -> xmlel_any()).
 
 remove_element(#xmlel{children = Children} = XML_Element, Name) ->
     New_Children = remove_element2(Children, Name),
@@ -2226,7 +2226,7 @@ remove_element3([], _Name, Result) ->
 %%     New_XML_Element = xmlel()
 %% @doc Remove the first child with the name `Name' in the namespace `NS'.
 
--spec(remove_element/3 :: (xmlel(), xmlname(), xmlname()) -> xmlel()).
+-spec(remove_element (xmlel(), xmlname(), xmlname()) -> xmlel()).
 
 remove_element(#xmlel{children = Children} = XML_Element, NS, Name) ->
     New_Children = remove_element2(Children, NS, Name),
@@ -2251,7 +2251,7 @@ remove_element3([], _NS, _Name, Result) ->
 %%     New_XML_Element = xmlel()
 %% @doc Remove the first child in the namespace `NS'.
 
--spec(remove_element_by_ns/2 :: (xmlel(), xmlname()) -> xmlel()).
+-spec(remove_element_by_ns (xmlel(), xmlname()) -> xmlel()).
 
 remove_element_by_ns(#xmlel{children = Children} = XML_Element, NS) ->
     New_Children = remove_element_by_ns2(Children, NS),
@@ -2276,7 +2276,7 @@ remove_element_by_ns3([], _NS, Result) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Remove all children with the name `Name'.
 
--spec(remove_elements/2 :: (xmlel_any(), xmlname()) -> xmlel_any()).
+-spec(remove_elements (xmlel_any(), xmlname()) -> xmlel_any()).
 
 remove_elements(#xmlel{children = Children} = XML_Element, Name) ->
     New_Children = remove_elements2(Children, Name),
@@ -2305,7 +2305,7 @@ remove_elements3([], _Name, Result) ->
 %%     New_XML_Element = xmlel()
 %% @doc Remove all children with the name `Name' in the namespace `NS'.
 
--spec(remove_elements/3 :: (xmlel(), xmlname(), xmlname()) -> xmlel()).
+-spec(remove_elements (xmlel(), xmlname(), xmlname()) -> xmlel()).
 
 remove_elements(#xmlel{children = Children} = XML_Element, NS, Name) ->
     New_Children = remove_elements2(Children, NS, Name),
@@ -2330,7 +2330,7 @@ remove_elements3([], _NS, _Name, Result) ->
 %%     New_XML_Element = xmlel()
 %% @doc Remove all children in the namespace `NS'.
 
--spec(remove_elements_by_ns/2 :: (xmlel(), xmlname()) -> xmlel()).
+-spec(remove_elements_by_ns (xmlel(), xmlname()) -> xmlel()).
 
 remove_elements_by_ns(#xmlel{children = Children} = XML_Element, NS) ->
     New_Children = remove_elements_by_ns2(Children, NS),
@@ -2355,7 +2355,7 @@ remove_elements_by_ns3([], _NS, Result) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Prepend `Child' to `XML_Element''s children list.
 
--spec(prepend_child/2 :: (xmlel_any(), xmlnode()) -> xmlel_any()).
+-spec(prepend_child (xmlel_any(), xmlnode()) -> xmlel_any()).
 
 prepend_child(#xmlel{children = undefined} = XML_Element, Child) ->
     New_Children = [Child],
@@ -2376,7 +2376,7 @@ prepend_child(#xmlelement{children = Children} = XML_Element, Child) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Prepend every `Children' to `XML_Element''s children list.
 
--spec(prepend_children/2 :: (xmlel_any(), [xmlnode()]) -> xmlel_any()).
+-spec(prepend_children (xmlel_any(), [xmlnode()]) -> xmlel_any()).
 
 prepend_children(#xmlel{children = undefined} = XML_Element,
 		 New_Children) ->
@@ -2399,7 +2399,7 @@ prepend_children(#xmlelement{children = Children} = XML_Element,
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Append `Child' to `XML_Element''s children list.
 
--spec(append_child/2 :: (xmlel_any(), xmlnode()) -> xmlel_any()).
+-spec(append_child (xmlel_any(), xmlnode()) -> xmlel_any()).
 
 append_child(#xmlel{children = undefined} = XML_Element, Child) ->
     New_Children = [Child],
@@ -2420,7 +2420,7 @@ append_child(#xmlelement{children = Children} = XML_Element, Child) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Append every `Children' to `XML_Element''s children list.
 
--spec(append_children/2 :: (xmlel_any(), [xmlnode()]) -> xmlel_any()).
+-spec(append_children (xmlel_any(), [xmlnode()]) -> xmlel_any()).
 
 append_children(#xmlel{children = undefined} = XML_Element,
 		New_Children) ->
@@ -2445,7 +2445,7 @@ append_children(#xmlelement{children = Children} = XML_Element,
 %% @doc Replace `Old_Child' by `New_Child' in `XML_Element' children
 %% list.
 
--spec(replace_child/3 :: (xmlel_any(), xmlnode(), xmlnode()) -> xmlel_any()).
+-spec(replace_child (xmlel_any(), xmlnode(), xmlnode()) -> xmlel_any()).
 
 replace_child(#xmlel{children = Children} = XML_Element,
 	      Old_Child, New_Child) ->
@@ -2476,7 +2476,7 @@ replace_child2(Children, Old_Child, New_Child) ->
 %%
 %% Any existing child is removed.
 
--spec(set_children/2 :: (xmlel_any(), [xmlnode()]) -> xmlel_any()).
+-spec(set_children (xmlel_any(), [xmlnode()]) -> xmlel_any()).
 
 set_children(#xmlel{} = XML_Element, New_Children)
   when is_list(New_Children) ->
@@ -2499,7 +2499,7 @@ set_children(#xmlelement{} = XML_Element, New_Children)
 %%
 %% If `children' is `undefined', the function isn't called.
 
--spec(filter/2 ::
+-spec(filter
       (fun((xmlel_any(), xmlnode()) -> bool()), xmlel_any()) -> xmlel_any()).
 
 filter(Pred, #xmlel{children = Children} = XML_Element)
@@ -2532,7 +2532,7 @@ filter2(Pred, XML_Element, Children) ->
 %% fun(Acc_In, XML_Element, Child) -> Acc_Out
 %% '''
 
--spec(fold/3 ::
+-spec(fold
       (fun((any(), xmlel_any(), xmlnode() | undefined) -> any()), any(), xmlel_any()) ->
 	     any()).
 
@@ -2563,7 +2563,7 @@ fold2(_Fun, Acc_Out, _XML_Element, []) ->
 %% fun(XML_Element, Child) -> Ignored
 %% '''
 
--spec(foreach/2 ::
+-spec(foreach
       (fun((xmlel_any(), xmlnode() | undefined) -> any()), xmlel_any()) ->
 	     ok).
 
@@ -2599,7 +2599,7 @@ foreach2(_Fun, _XML_Element, []) ->
 %%
 %% If `children' is `undefined', the function isn't called.
 
--spec(map/2 ::
+-spec(map
       (fun((xmlel_any(), xmlnode()) -> xmlnode()), xmlel_any()) ->
 	     xmlel_any()).
 
@@ -2629,7 +2629,7 @@ map2(_Fun, _XML_Element, []) ->
 %%     CData = xmlcdata()
 %% @doc Create a CData node from a value.
 
--spec(cdata/1 :: (binary() | string() | atom() | integer()) -> xmlcdata()).
+-spec(cdata (binary() | string() | atom() | integer()) -> xmlcdata()).
 
 cdata(CData) ->
     #xmlcdata{cdata = exmpp_utils:any_to_binary(CData)}.
@@ -2640,7 +2640,7 @@ cdata(CData) ->
 %% @doc Concatenate and return any character data from the given
 %% children list.
 
--spec(get_cdata_from_list/1 :: ([xmlnode()] | undefined) -> binary()).
+-spec(get_cdata_from_list ([xmlnode()] | undefined) -> binary()).
 
 get_cdata_from_list(undefined) ->
     <<>>;
@@ -2662,7 +2662,7 @@ get_cdata_from_list2([], Data) ->
 %% @doc Concatenate and return any character data from the given
 %% children list.
 
--spec(get_cdata_from_list_as_list/1 :: ([xmlnode()] | undefined) -> string()).
+-spec(get_cdata_from_list_as_list ([xmlnode()] | undefined) -> string()).
 
 get_cdata_from_list_as_list(Children) ->
     binary_to_list(get_cdata_from_list(Children)).
@@ -2677,7 +2677,7 @@ get_cdata_from_list_as_list(Children) ->
 %% doesn't take a list of children like the old `get_cdata/1', use
 %% {@link get_cdata_from_list/1} for this purpose!
 
--spec(get_cdata/1 :: (xmlel_any()) -> binary()).
+-spec(get_cdata (xmlel_any()) -> binary()).
 
 get_cdata(#xmlel{children = Children}) ->
     get_cdata_from_list(Children);
@@ -2694,7 +2694,7 @@ get_cdata(undefined) ->
 %% @doc Concatenate and return any character data of the given XML
 %% element.
 
--spec(get_cdata_as_list/1 :: (xmlel_any()) -> string()).
+-spec(get_cdata_as_list (xmlel_any()) -> string()).
 
 get_cdata_as_list(XML_Element) ->
     binary_to_list(get_cdata(XML_Element)).
@@ -2704,7 +2704,7 @@ get_cdata_as_list(XML_Element) ->
 %%     New_Children = [xmlel() | xmlel_old() | xmlcdata()] | undefined
 %% @doc Regroup all splitted {@link xmlcdata()} in a unique one.
 
--spec(normalize_cdata_in_list/1 ::
+-spec(normalize_cdata_in_list
       ([xmlnode()] | undefined) -> [xmlnode()] | undefined).
 
 normalize_cdata_in_list(undefined) ->
@@ -2739,7 +2739,7 @@ normalize_cdata_in_list2([XML_Node | Rest], Current_CDatas, New_Children) ->
 %% One caveats is the reconstructed {@link xmlcdata()} is appended at
 %% the end of the children list.
 
--spec(normalize_cdata/1 :: (xmlel_any()) -> xmlel_any()).
+-spec(normalize_cdata (xmlel_any()) -> xmlel_any()).
 
 normalize_cdata(#xmlel{children = Children} = XML_Element) ->
     New_Children = normalize_cdata_in_list(Children),
@@ -2756,7 +2756,7 @@ normalize_cdata(#xmlelement{children = Children} = XML_Element) ->
 %%
 %% The new `CData' is placed at the end of the children list.
 
--spec(set_cdata_in_list/2 ::
+-spec(set_cdata_in_list
       ([xmlnode()] | undefined, binary() | string() | atom() | integer()) ->
 	     [xmlnode()]).
 
@@ -2774,7 +2774,7 @@ set_cdata_in_list(Children, CData) ->
 %%
 %% The new `CData' is placed at the end of the children list.
 
--spec(set_cdata/2 ::
+-spec(set_cdata
       (xmlel_any(), binary() | string() | atom() | integer()) -> xmlel_any()).
 
 set_cdata(#xmlel{children = Children} = XML_Element, CData) ->
@@ -2790,7 +2790,7 @@ set_cdata(#xmlelement{children = Children} = XML_Element, CData) ->
 %%     New_Children = [xmlel() | xmlel_old() | xmlcdata()]
 %% @doc Append `CData' to `Children' list.
 
--spec(append_cdata_to_list/2 ::
+-spec(append_cdata_to_list
       ([xmlnode()] | undefined, binary() | string() | atom() | integer()) ->
 	     [xmlnode()]).
 
@@ -2805,7 +2805,7 @@ append_cdata_to_list(Children, CData) ->
 %%     New_XML_Element = xmlel() | xmlel_old()
 %% @doc Append `Child' to `XML_Element''s children list.
 
--spec(append_cdata/2 ::
+-spec(append_cdata
       (xmlel_any(), binary() | string() | atom() | integer()) -> xmlel_any()).
 
 append_cdata(#xmlel{children = Children} = XML_Element, CData) ->
@@ -2821,7 +2821,7 @@ append_cdata(#xmlelement{children = Children} = XML_Element, CData) ->
 %% @doc Remove any character data from the given XML element children
 %% list.
 
--spec(remove_cdata_from_list/1 ::
+-spec(remove_cdata_from_list
       ([xmlnode()] | undefined) -> [xmlnode()] | undefined).
 
 remove_cdata_from_list(undefined) ->
@@ -2841,7 +2841,7 @@ remove_cdata_from_list2(_)           -> true.
 %% `remove_cdata/1', use {@link remove_cdata_from_list/1} for this
 %% purpose!
 
--spec(remove_cdata/1 :: (xmlel_any()) -> xmlel_any()).
+-spec(remove_cdata (xmlel_any()) -> xmlel_any()).
 
 remove_cdata(#xmlel{children = Children} = XML_Element) ->
     New_Children = remove_cdata_from_list(Children),
@@ -2859,7 +2859,7 @@ remove_cdata(#xmlelement{children = Children} = XML_Element) ->
 %%
 %% Whitespaces are `\s', `\t', `\n' and `\r'.
 
--spec(is_whitespace/1 :: (xmlnode()) -> bool()).
+-spec(is_whitespace (xmlnode()) -> bool()).
 
 is_whitespace(#xmlcdata{cdata = CData}) ->
     is_whitespace2(CData);
@@ -2881,7 +2881,7 @@ is_whitespace2(_CData) ->
 %%
 %% @see is_whitespace/1.
 
--spec(remove_whitespaces_from_list/1 ::
+-spec(remove_whitespaces_from_list
       ([xmlnode()] | undefined) -> [xmlnode()] | undefined).
 
 remove_whitespaces_from_list(undefined) ->
@@ -2896,7 +2896,7 @@ remove_whitespaces_from_list(Children) ->
 %%
 %% @see is_whitespace/1.
 
--spec(remove_whitespaces/1 :: (xmlel_any()) -> xmlel_any()).
+-spec(remove_whitespaces (xmlel_any()) -> xmlel_any()).
 
 remove_whitespaces(#xmlel{children = Children} = XML_Element) ->
     New_Children = remove_whitespaces_from_list(Children),
@@ -2913,7 +2913,7 @@ remove_whitespaces(#xmlelement{children = Children} = XML_Element) ->
 %%
 %% @see is_whitespace/1.
 
--spec(remove_whitespaces_deeply/1 :: (xmlel_any()) -> xmlel_any()).
+-spec(remove_whitespaces_deeply (xmlel_any()) -> xmlel_any()).
 
 remove_whitespaces_deeply(#xmlel{children = Children} = XML_Element) ->
     New_Children = remove_whitespaces_deeply2(Children),
@@ -2970,7 +2970,7 @@ remove_whitespaces_deeply3([], Result) ->
 %% isn't found while walking through the path, an empty string is
 %% returned.
 
--spec(get_path/2 ::
+-spec(get_path
       (xmlel(), xmlpath()) -> xmlel_any() | binary() | string() | undefined).
 
 get_path(XML_Element, [{element, Name} | Path]) ->
@@ -3040,7 +3040,7 @@ get_path_not_found(Path) ->
 %%
 %% Other tuples are ignored.
 
--spec(xmlel_to_xmlelement/1 :: (xmlel()) -> xmlel_old()).
+-spec(xmlel_to_xmlelement (xmlel()) -> xmlel_old()).
 
 xmlel_to_xmlelement(XML_Element) ->
     xmlel_to_xmlelement(XML_Element, [], []).
@@ -3075,7 +3075,7 @@ xmlel_to_xmlelement(XML_Element) ->
 %%   [?NS_JABBER_CLIENT, ?NS_JABBER_SERVER, ?NS_COMPONENT_ACCEPT]).
 %% '''
 
--spec(xmlel_to_xmlelement/3 ::
+-spec(xmlel_to_xmlelement
       (xmlel(), xmldefaultnss(), xmlprefixednss()) -> xmlel_old()).
 
 xmlel_to_xmlelement(#xmlel{children = Children} = El,
@@ -3306,7 +3306,7 @@ new_auto_prefix2(Prefixed_NS, Seq) ->
 %%
 %% Other tuples are ignored.
 
--spec(xmlelement_to_xmlel/1 :: (xmlel_old()) -> xmlel()).
+-spec(xmlelement_to_xmlel (xmlel_old()) -> xmlel()).
 
 xmlelement_to_xmlel(XML_Element) ->
     xmlelement_to_xmlel(XML_Element, [], []).
@@ -3326,7 +3326,7 @@ xmlelement_to_xmlel(XML_Element) ->
 %% See {@link xmlel_to_xmlelement/3} for a description of
 %% `Default_NS' and `Prefixed_NS'.
 
--spec(xmlelement_to_xmlel/3 ::
+-spec(xmlelement_to_xmlel
       (xmlel_old(), xmldefaultnss(), xmlprefixednss()) -> xmlel()).
 
 xmlelement_to_xmlel(XML_El, Default_NS, Prefixed_NS) ->
@@ -3355,7 +3355,7 @@ xmlelement_to_xmlel(XML_El, Default_NS, Prefixed_NS) ->
 %% `New_Default_NS' and `New_Prefixed_NS' which can be used for future
 %% calls.
 
--spec(xmlelement_to_xmlel_and_nss_tables/3 ::
+-spec(xmlelement_to_xmlel_and_nss_tables
       (xmlel_old(), xmldefaultnss(), xmlprefixednss()) ->
 	     {xmlel(), xmldefaultnss(), xmlprefixednss()}).
 
@@ -3563,7 +3563,7 @@ search_prefix_in_prefixed_ns(Prefix, Prefixed_NS) ->
 %% important: declarations are sorted from the most recent one to the
 %% oldest one.
 
--spec(node_to_list/3 ::
+-spec(node_to_list
       (xmlel_any() | [xmlel_any()], xmldefaultnss(), xmlprefixednss()) -> string()).
 
 node_to_list(El, Default_NS, Prefixed_NS) ->
@@ -3575,7 +3575,7 @@ node_to_list(El, Default_NS, Prefixed_NS) ->
 %%     XML_Text = string()
 %% @doc Serialize an XML document to text.
 
--spec(document_to_list/1 :: (xmlel_any()) -> string()).
+-spec(document_to_list (xmlel_any()) -> string()).
 
 document_to_list(El) ->
     node_to_list(El, [], []).
@@ -3593,7 +3593,7 @@ document_to_list(El) ->
 %% Converting to binary is about 15% to 20% faster than converting to a
 %% list.
 
--spec(node_to_binary/3 ::
+-spec(node_to_binary
       (xmlel_any() | [xmlel_any()]| #xmlendtag{}, xmldefaultnss(), xmlprefixednss()) -> binary()).
 
 node_to_binary(El, Default_NS, Prefixed_NS) ->
@@ -3608,7 +3608,7 @@ node_to_binary(El, Default_NS, Prefixed_NS) ->
 %% Converting to binary is about 15% to 20% faster than converting to a
 %% list.
 
--spec(document_to_binary/1 :: (xmlel_any()) -> binary()).
+-spec(document_to_binary (xmlel_any()) -> binary()).
 
 document_to_binary(El) ->
     node_to_binary(El, [], []).
@@ -3629,7 +3629,7 @@ document_to_binary(El) ->
 %% TODO: transform directly to text without converting it to the old
 %%       xmlelement() first.
 
--spec(node_to_iolist/3 ::
+-spec(node_to_iolist
       (xmlel_any() | [xmlel_any()]| #xmlendtag{}, xmldefaultnss(), xmlprefixednss()) -> iolist()).
 
 node_to_iolist(El, Default_NS, Prefixed_NS) when is_list(El) ->
@@ -3697,7 +3697,7 @@ attr_to_iolist({Name, Value}) ->
 %%     XML_Text = iolist()
 %% @doc Serialize an XML document to text.
 
--spec(document_to_iolist/1 :: (xmlel_any()) -> iolist()).
+-spec(document_to_iolist (xmlel_any()) -> iolist()).
 
 document_to_iolist(El) ->
     node_to_iolist(El, [], []).
@@ -3709,7 +3709,7 @@ document_to_iolist(El) ->
 %%
 %% @see is_whitespace/1.
 
--spec(deindent_document/1 :: (xmlel_any()) -> xmlel_any()).
+-spec(deindent_document (xmlel_any()) -> xmlel_any()).
 
 deindent_document(#xmlel{children = Children} = El) ->
     New_Children = deindent_children(remove_whitespaces_from_list(Children)),
@@ -3741,7 +3741,7 @@ deindent_children2([Child | Rest], Result)
 %%
 %% Indentation of {@link xmlendtag()} isn't supported yet.
 
--spec(indent_document/2 :: (xmlel_any(), binary()) -> xmlel_any()).
+-spec(indent_document (xmlel_any(), binary()) -> xmlel_any()).
 
 indent_document(El, Indent) ->
     indent_document(El, Indent, <<>>).
@@ -3755,7 +3755,7 @@ indent_document(El, Indent) ->
 %%
 %% Indentation of {@link xmlendtag()} isn't supported yet.
 
--spec(indent_document/3 :: (xmlel_any(), binary(), binary()) -> xmlel_any()).
+-spec(indent_document (xmlel_any(), binary(), binary()) -> xmlel_any()).
 
 indent_document(El, Indent, Previous_Total) ->
     %% First, we remove previous indentation.
@@ -3809,7 +3809,7 @@ indent_children2([Child | Rest], Indent, Previous_Total, Before, End, Result)
 %% option (see {@link xmlparseroption()}) wasn't specified at {@link
 %% start_parser/1} time.
 
--spec(clear_endtag_tuples/1 :: ([xmlnode() | xmlendtag()]) -> [xmlnode()]).
+-spec(clear_endtag_tuples ([xmlnode() | xmlendtag()]) -> [xmlnode()]).
 
 clear_endtag_tuples(XML_Elements) ->
     clear_endtag_tuples2(XML_Elements, []).
@@ -3829,7 +3829,7 @@ clear_endtag_tuples2([], Result) ->
 %% Processed characters are <tt>&amp;</tt>, <tt>&lt;</tt>,
 %% <tt>&gt;</tt>, <tt>&quot;</tt>, <tt>&apos;</tt>.
 
--spec(escape_using_entities/1 :: (binary() | string()) -> binary() | string()).
+-spec(escape_using_entities (binary() | string()) -> binary() | string()).
 
 escape_using_entities(CData) when is_list(CData) ->
     lists:flatten([case C of
@@ -3859,7 +3859,7 @@ escape_using_entities2(<<>>, New_CData) ->
 
 
 
--spec(escape_attr_using_entities/1 :: (binary() | string()) -> binary() | string()).
+-spec(escape_attr_using_entities (binary() | string()) -> binary() | string()).
 
 escape_attr_using_entities(CData) when is_list(CData) ->
     lists:flatten([case C of
@@ -3899,7 +3899,7 @@ escape_attr_using_entities2(<<>>, New_CData) ->
 %%     Escaped_CData = string() | binary()
 %% @doc Escape text using CDATA sections.
 
--spec(escape_using_cdata/1 :: (binary() | string()) -> binary() | string()).
+-spec(escape_using_cdata (binary() | string()) -> binary() | string()).
 
 escape_using_cdata(CData) when is_list(CData) ->
     escape_using_cdata_list(CData, false, []);
@@ -3984,7 +3984,7 @@ escape_using_cdata_binary2(CData, Current_Pos, [Pos | End_Token_Pos],
 %% @spec () -> escape_using_entities | escape_using_cdata
 %% @doc Tell what escaping function will be used internally.
 
--spec(internal_escaping_function_name/0 ::
+-spec(internal_escaping_function_name
       () -> escape_using_cdata | escape_using_entities).
 
 -ifdef(ESCAPE_USING_CDATA_SECTIONS).

--- a/src/core/exmpp_xmlstream.erl
+++ b/src/core/exmpp_xmlstream.erl
@@ -91,7 +91,7 @@
 %% @see exmpp_xml:start_parser/1.
 %% @see exmpp_xml:reset_parser/2.
 
--spec(start/2 ::
+-spec(start
       (callback(), exmpp_xml:xmlparser()) -> xmlstream()).
 
 start(Callback, Parser) ->
@@ -113,7 +113,7 @@ start(Callback, Parser) ->
 %% @see exmpp_xml:start_parser/1.
 %% @see exmpp_xml:reset_parser/2.
 
--spec(start/3 ::
+-spec(start
       (callback(), exmpp_xml:xmlparser(), [{xmlstreamstart, new | old}]) ->
 	     xmlstream()).
 
@@ -140,7 +140,7 @@ start(Callback, Parser, Stream_Options) ->
 %%     New_Stream = xmlstream()
 %% @doc Reset stream and the underlying XML parser.
 
--spec(reset/1 :: (xmlstream()) -> xmlstream()).
+-spec(reset (xmlstream()) -> xmlstream()).
 
 reset(#xml_stream{parser = Parser} = Stream) ->
     New_Parser = exmpp_xml:reset_parser(Parser),
@@ -151,7 +151,7 @@ reset(#xml_stream{parser = Parser} = Stream) ->
 %%     Parser = exmpp_xml:xmlparser()
 %% @doc Return the XML parser used.
 
--spec(get_parser/1 :: (xmlstream()) -> exmpp_xml:xmlparser()).
+-spec(get_parser (xmlstream()) -> exmpp_xml:xmlparser()).
 
 get_parser(#xml_stream{parser = Parser}) ->
     Parser.
@@ -169,7 +169,7 @@ get_parser(#xml_stream{parser = Parser}) ->
 %%
 %% @see get_parser/1.
 
--spec(stop/1 :: (xmlstream()) -> ok).
+-spec(stop (xmlstream()) -> ok).
 
 stop(_Stream) ->
     ok.
@@ -187,7 +187,7 @@ stop(_Stream) ->
 %%
 %% Potential events are described by the {@link xmlstreamevent()} type.
 
--spec(parse/2 ::
+-spec(parse
       (xmlstream(), binary() | string()) ->
 	     {ok, xmlstream()} | {ok, xmlstream(), [xmlstreamevent()]} |
 		 {error, any()}).
@@ -324,7 +324,7 @@ send_events(Stream, []) ->
 %%     NewStream = xmlstream()
 %% @doc Change callback of the stream.
 
--spec(change_callback/2 :: (xmlstream(), callback()) -> xmlstream()).
+-spec(change_callback (xmlstream(), callback()) -> xmlstream()).
 
 change_callback(Stream, CallBack) ->
     NewCallBack = if is_pid(CallBack) ->
@@ -348,7 +348,7 @@ change_callback(Stream, CallBack) ->
 %% @see exmpp_xml:start_parser/0.
 %% @see exmpp_xml:parse_document/1.
 
--spec(parse_element/1 ::
+-spec(parse_element
       (binary() | string()) ->
 	     [xmlnode() | xmlendtag()]).
 
@@ -366,7 +366,7 @@ parse_element(Data) ->
 %% @see exmpp_xml:start_parser/1.
 %% @see exmpp_xml:parse_document/2.
 
--spec(parse_element/2 ::
+-spec(parse_element
       (binary() | string(), [exmpp_xml:xmlparseroption()]) ->
 	     [xmlnode() | xmlendtag()]).
 
@@ -387,7 +387,7 @@ parse_element(Data, Parser_Options) ->
 %% @doc Reset stream and the underlying XML parser.
 %% TODO: Support wrapper tag match on both namespace and name ?
 
--spec(set_wrapper_tagnames/2 :: (xmlstream(), [atom()|string()]) -> xmlstream()).
+-spec(set_wrapper_tagnames (xmlstream(), [atom()|string()]) -> xmlstream()).
 
 set_wrapper_tagnames(Stream, TagNames) when is_list(TagNames) ->
     Stream#xml_stream{wrapper_tagnames = TagNames}.

--- a/src/network/exmpp_session.erl
+++ b/src/network/exmpp_session.erl
@@ -388,7 +388,7 @@ send_packet(Session, Packet) when is_pid(Session) ->
 %%
 %%      See documentation on exmpp_socket and exmpp_bosh to see the supported properties.
 %%      Returns {error, undefined} if the property is not defined for that kind of connection.
--spec(get_connection_property/2 :: 
+-spec(get_connection_property 
         (pid(), atom()) -> {ok, any()} | {error, any()}).
 get_connection_property(Session, Prop) ->
     gen_fsm:sync_send_all_state_event(Session, {get_connection_property, Prop}).


### PR DESCRIPTION
as title